### PR TITLE
WindowClient.focus() resolves with updated WindowClient.

### DIFF
--- a/spec/service_worker/index.html
+++ b/spec/service_worker/index.html
@@ -802,7 +802,7 @@ interface <dfn id="window-client-interface" title="WindowClient">WindowClient</d
   readonly attribute <a href="http://www.w3.org/TR/page-visibility/#VisibilityState">VisibilityState</a> <a href="http://www.w3.org/TR/page-visibility/#dom-document-visibilitystate">visibilityState</a>;
   readonly attribute boolean focused;
   readonly attribute <a href="#context-frame-type-enum">ContextFrameType</a> frameType;
-  <a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise-objects">Promise</a>&lt;void&gt; focus();
+  <a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise-objects">Promise</a>&lt;<a href="#window-client-interface">WindowClient</a>&gt; focus();
 };
 
 enum <dfn id="context-frame-type-enum" title="ContextFrameType">ContextFrameType</dfn> {


### PR DESCRIPTION
This is following the discussion in https://github.com/slightlyoff/ServiceWorker/issues/588

CC @annevk  @jakearchibald 