### PR TITLE
Expanded on the update() Note:

### DIFF
--- a/spec/service_worker/index.html
+++ b/spec/service_worker/index.html
@@ -336,7 +336,7 @@ interface <dfn id="service-worker-registration-interface" title="ServiceWorkerRe
     <spec-section id="service-worker-registration-update">
       <h1><code>update()</code></h1>
 
-      <p class="note"><code>update()</code> pings the server for an updated version of this script without consulting caches. This is conceptually the same operation that UA does maximum once per every 24 hours.</p>
+      <p class="note">When loading a registered service worker script, the UA normally checks the HTTP cache for an unexpired copy, falling back on network retrieval otherwise. <code>update()</code> will force the UA to consult the server updated script, ignoring the HTTP cache. <code>update()</code>'s behavior is conceptually the same as what the UA does a maximum once every 24 hours on its own, to prevent service worker scripts from being cached for longer than a day.</p>
       <p><dfn id="service-worker-registration-update-method"><code>update()</code></dfn> method must run these steps or their <a href="#dfn-processing-equivalence">equivalent</a>:</p>
       <spec-algorithm>
       <ol>


### PR DESCRIPTION
@jakearchibald @slightlyoff:

Here's my take on elaborating the `update()` Note, to clarify that, by default, the browser's HTTP cache is consulted for an unexpired copy of the service worker script, and that `update()` skips the HTTP cache.

I hadn't previously been clear on whether it was the browser HTTP cache that was consulted or some service worker-specific cache—the impression that I got was that service workers scripts were always cached for 24 hours, and the only way to achieve a quicker cache expiration was to call `update()`.