### PR TITLE
Remove "parsed" state mention

### DIFF
--- a/spec/service_worker/index.html
+++ b/spec/service_worker/index.html
@@ -128,7 +128,7 @@
   <spec-section id="service-worker-concept">
     <h1>Service Worker</h1>
     <p>A <dfn id="dfn-service-worker">service worker</dfn> is a type of <a href="http://www.w3.org/TR/workers/">web worker</a>. A <a href="#dfn-service-worker">service worker</a> executes in the registering <a href="#dfn-service-worker-client">service worker client</a>'s <a href="https://html.spec.whatwg.org/multipage/browsers.html#origin-2">origin</a>.</p>
-    <p>A <a href="#dfn-service-worker">service worker</a> has an associated <dfn id="dfn-state">state</dfn>, which is one of <em>parsed</em>, <em>installing</em>, <em>installed</em>, <em>activating</em>, <em>activated</em>, and <em>redundant</em>. (Initially <em>parsed</em>).</p>
+    <p>A <a href="#dfn-service-worker">service worker</a> has an associated <dfn id="dfn-state">state</dfn>, which is one of <em>installing</em>, <em>installed</em>, <em>activating</em>, <em>activated</em>, and <em>redundant</em>.</p>
     <p>A <a href="#dfn-service-worker">service worker</a> has an associated <dfn id="dfn-script-url">script url</dfn> (a <a href="https://url.spec.whatwg.org/#concept-url">URL</a>).</p>
     <p>A <a href="#dfn-service-worker">service worker</a> has an associated <dfn id="dfn-containing-service-worker-registration">containing service worker registration</dfn> (a <a href="#dfn-service-worker-registration">service worker registration</a>), which contains itself.</p>
     <p>A <a href="#dfn-service-worker">service worker</a> has an associated <dfn id="dfn-service-worker-id">id</dfn> (a <a href="http://tools.ietf.org/html/rfc4122#section-3">UUID</a>), which uniquely identifies itself during the lifetime of its <a href="#dfn-containing-service-worker-registration">containing service worker registration</a>.</p>


### PR DESCRIPTION
`parsed` is no longer listed as a possible state at http://www.w3.org/TR/service-workers/#service-worker-state