### PR TITLE
typo: excecution -> execution

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -6,7 +6,7 @@ Service Workers are being developed to answer frequent questions and concerns ab
 
  * An inability to explain (in the [Extensible Web Manifesto](https://extensiblewebmanifesto.org/) sense) HTTP caching and high-level HTTP interactions like the HTML5 AppCache
  * Difficulty in building offline-first web applications in a natural way
- * The lack of a background excecution context which many proposed capabilities could make use of
+ * The lack of a background execution context which many proposed capabilities could make use of
 
 We also note that the long lineage of declarative-only solutions ([Google Gears, [Dojo Offline](http://www.sitepen.com/blog/category/dojo-offline/), and [HTML5 AppCache](http://alistapart.com/article/application-cache-is-a-douchebag)) have failed to deliver on their promise. Each successive declarative-only approach failed in many of the same ways, so the Service Worker effort has taken a different design approach: a largely-imperative system that puts developers firmly in control.
 


### PR DESCRIPTION
There's not much to this; I just noticed a typo and thought you might like to merge the fix.