### PR TITLE
Fix spelling error: arguement -> argument

### DIFF
--- a/spec/service_worker/index.html
+++ b/spec/service_worker/index.html
@@ -319,7 +319,7 @@ navigator.serviceWorker.register("/service_worker.js", { scope: "/" });</spec-co
         </li>
         <li>Let <var>clonedMessage</var> be a <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#structured-clone">structured clone</a> of <var>message</var> with <var>transferMap</var> as the <var>transferMap</var>. If this <a href="http://heycam.github.io/webidl/#dfn-throw">throws</a> an exception, <a href="http://heycam.github.io/webidl/#dfn-throw">rethrow</a> that exception and abort these steps.</li>
         <li>Let <var>serviceWorker</var> be the <a href="#dfn-service-worker">service worker</a> represented by the <a href="https://dom.spec.whatwg.org/#context-object">context object</a>.</li>
-        <li>Invoke <a href="#run-service-worker-algorithm">Run Service Worker</a> algorithm with <var>serviceWorker</var> as the arguement.</li>
+        <li>Invoke <a href="#run-service-worker-algorithm">Run Service Worker</a> algorithm with <var>serviceWorker</var> as the argument.</li>
         <li>Let <var>destination</var> be the <code><a href="#service-worker-global-scope-interface">ServiceWorkerGlobalScope</a></code> object associated with <var>serviceWorker</var>.</li>
         <li>If the method was invoked with a second argument <var>transfer</var>, run these substeps:
           <ol>
@@ -2579,7 +2579,7 @@ interface FunctionalEvent : ExtendableEvent {
               <li>Let <var>worker</var> be a new <a href="#dfn-service-worker">service worker</a>.</li>
               <li>Generate a unique opaque string and set <var>worker</var>'s <a href="#dfn-service-worker-id">id</a> to the value.</li>
               <li>Set <var>worker</var>'s <a href="#dfn-script-url">script url</a> to <var>registration</var>'s <a href="#dfn-registration-script-url">registering script url</a>, <var>worker</var>'s <a href="#dfn-script-resource">script resource</a> to the script resource retrieved from the fetched <var>response</var>.</li>
-              <li>Invoke <a href="#run-service-worker-algorithm">Run Service Worker</a> algorithm with <var>worker</var> as the arguement.</li>
+              <li>Invoke <a href="#run-service-worker-algorithm">Run Service Worker</a> algorithm with <var>worker</var> as the argument.</li>
               <li>If an uncaught runtime script error occurs during the above step, then:
                 <ol>
                   <li>Reject <var>p</var> with the error.</li>
@@ -2662,7 +2662,7 @@ interface FunctionalEvent : ExtendableEvent {
       <li>Resolve <var>registrationPromise</var> with the <code><a href="#service-worker-registration-interface">ServiceWorkerRegistration</a></code> object, setting its <a href="#dfn-service-worker-registration-interface-client">service worker client</a> to <var>client</var>, which represents <var>registration</var>.</li>
       <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> to <a href="https://html.spec.whatwg.org/#fire-a-simple-event">fire a simple event named</a> <code>updatefound</code> at all the <code><a href="#service-worker-registration-interface">ServiceWorkerRegistration</a></code> objects that represent <var>registration</var> for all the <a href="#dfn-service-worker-client">service worker clients</a> whose <a href="https://html.spec.whatwg.org/multipage/webappapis.html#creation-url">creation url</a> <a href="#scope-match-algorithm">matches</a> <var>registration</var>'s <a href="#dfn-scope-url">scope url</a>.</li>
       <li>Let <var>installingWorker</var> be <var>registration</var>'s <a href="#dfn-installing-worker">installing worker</a>.</li>
-      <li>Invoke <a href="#run-service-worker-algorithm">Run Service Worker</a> algorithm with <var>installingWorker</var> as the arguement.</li>
+      <li>Invoke <a href="#run-service-worker-algorithm">Run Service Worker</a> algorithm with <var>installingWorker</var> as the argument.</li>
       <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> <var>task</var> to run the following substeps:
         <ol>
           <li>Create a <a href="https://html.spec.whatwg.org/#concept-events-trusted">trusted</a> event <var>e</var> that uses the <code><a href="#extendable-event-interface">ExtendableEvent</a></code> interface, with the event type <code><a href="#service-worker-global-scope-install-event">install</a></code>, which does not bubble, is not cancelable, and has no default action.</li>
@@ -2837,7 +2837,7 @@ interface FunctionalEvent : ExtendableEvent {
         </ol>
       </li>
       <li>Let <var>activeWorker</var> be <var>registration</var>'s <a href="#dfn-active-worker">active worker</a>.</li>
-      <li>Invoke <a href="#run-service-worker-algorithm">Run Service Worker</a> algorithm with <var>activeWorker</var> as the arguement.</li>
+      <li>Invoke <a href="#run-service-worker-algorithm">Run Service Worker</a> algorithm with <var>activeWorker</var> as the argument.</li>
       <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> <var>task</var> to run the following substeps:
         <ol>
           <li>Create a <a href="https://html.spec.whatwg.org/#concept-events-trusted">trusted</a> event <var>e</var> that uses the <code><a href="#extendable-event-interface">ExtendableEvent</a></code> interface, with the event type <code><a href="#service-worker-global-scope-activate-event">activate</a></code>, which does not bubble, is not cancelable, and has no default action.</li>
@@ -2989,7 +2989,7 @@ interface FunctionalEvent : ExtendableEvent {
           <li>Wait for <var>activeWorker</var>'s <a href="#dfn-state">state</a> to become <em>activated</em>.</li>
         </ol>
       </li>
-      <li>Invoke <a href="#run-service-worker-algorithm">Run Service Worker</a> algorithm with <var>activeWorker</var> as the arguement.</li>
+      <li>Invoke <a href="#run-service-worker-algorithm">Run Service Worker</a> algorithm with <var>activeWorker</var> as the argument.</li>
       <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> <var>task</var> to run the following substeps:
         <ol>
           <li>Create a <a href="https://html.spec.whatwg.org/#concept-events-trusted">trusted</a> event <var>e</var> that uses the <code><a href="#fetch-event-interface">FetchEvent</a></code> interface, with the event type <code><a href="#service-worker-global-scope-fetch-event">fetch</a></code>, which does not bubble and has no default action.</li>
@@ -3103,7 +3103,7 @@ interface FunctionalEvent : ExtendableEvent {
       <li><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-algorithm-conventions">Assert</a>: a <a href="http://www.ecma-international.org/ecma-262/6.0/#sec-list-and-record-specification-type">Record</a> with the [[value]] equals to <var>registration</var> is contained in <a href="#dfn-scope-to-registration-map">scope to registration map</a>.</li>
       <li><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-algorithm-conventions">Assert</a>: <var>registration</var>'s <a href="#dfn-active-worker">active worker</a> is not null.</li>
       <li>Let <var>activeWorker</var> be <var>registration</var>'s <a href="#dfn-active-worker">active worker</a>.</li>
-      <li>Invoke <a href="#run-service-worker-algorithm">Run Service Worker</a> algorithm with <var>activeWorker</var> as the arguement.</li>
+      <li>Invoke <a href="#run-service-worker-algorithm">Run Service Worker</a> algorithm with <var>activeWorker</var> as the argument.</li>
       <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> <var>task</var> to invoke <var>callbackSteps</var> with <var>activeWorker</var>'s <a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object"> environment settings object</a>'s <a href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object">global object</a> as its argument.
         <p>The <var>task</var> <em class="rfc2119" title="MUST">must</em> use <var>activeWorker</var>'s <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a> and the <a href="#dfn-handle-functional-event-task-source">handle functional event task source</a>.</p>
       </li>


### PR DESCRIPTION
Argument seems to have been misspelled a couple of times in the spec, this fixes those.