### PR TITLE
Use “service worker” consistently

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,22 @@
-## What's Going On Here?
+## What’s going on here?
 
-Service Workers are a new browser feature that provide event-driven scripts that run independently of web pages. Unlike other workers Service Workers can be shut down at the end of events, note the lack of retained references from documents, and they have access to domain-wide events such as network fetches.
+Service workers are a new browser feature that provide event-driven scripts that run independently of web pages. Unlike other workers, service workers can be shut down at the end of events, note the lack of retained references from documents, and they have access to domain-wide events such as network fetches.
 
-ServiceWorkers also have scriptable caches. Along with the ability to respond to network requests from certain web pages via script, this provides a way for applications to "go offline".
+Service workers also have scriptable caches. Along with the ability to respond to network requests from certain web pages via script, this provides a way for applications to “go offline”.
 
-Service Workers are meant to replace the ([oft maligned](http://alistapart.com/article/application-cache-is-a-douchebag)) [HTML5 Application Cache](//www.whatwg.org/specs/web-apps/current-work/multipage/offline.html). Unlike AppCache, Service Workers are comprised of scriptable primitives that make it possible for application developers to build URL-friendly, always-available applications in a sane and layered way.
+Service workers are meant to replace the ([oft maligned](http://alistapart.com/article/application-cache-is-a-douchebag)) [HTML5 Application Cache](https://html.spec.whatwg.org/multipage/browsers.html#offline). Unlike AppCache, service workers are comprised of scriptable primitives that make it possible for application developers to build URL-friendly, always-available applications in a sane and layered way.
 
-To understand the design and how you might build apps with ServiceWorkers, see the [explainer document](explainer.md).
+To understand the design and how you might build apps with service workers, see the [explainer document](explainer.md).
 
-## Spec and API Development
+## Spec and API development
 
-For the nitty-gritty of the API, the [draft W3C specification](//slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html) is authoritative. For implementers and developers who seek a more stable version, [Service Workers 1](//slightlyoff.github.io/ServiceWorker/spec/service_worker_1/index.html) is a right document with which the contributors only focus on fixing bugs and resolving compatibility issues.
+For the nitty-gritty of the API, the [draft W3C specification](https://slightlyoff.github.io/ServiceWorker/spec/service_worker/) is authoritative. For implementers and developers who seek a more stable version, [Service Workers 1](https://slightlyoff.github.io/ServiceWorker/spec/service_worker_1/) is a right document with which the contributors only focus on fixing bugs and resolving compatibility issues.
 
 Spec development happens via [issues in this repository](https://github.com/slightlyoff/ServiceWorker/issues). For general discussion, please use the [public-webapps@w3.org mailing list](http://lists.w3.org/Archives/Public/public-webapps/) with a `Subject:` prefix of `[service-workers]`.
 
 Updates to the spec must reference [resolved issued marked `needs spec`](issues?labels=needs+spec&state=closed).
 
-To edit the spec locally, you'll need a copy of [the Web Components-based framework which it is built with](//github.com/slightlyoff/web-spec-framework). To fetch it, clone the repo and run:
+To edit the spec locally, you’ll need a copy of [the Web Components-based framework which it is built with](https://github.com/slightlyoff/web-spec-framework). To fetch it, clone the repo and run:
 
 ```sh
 git submodule update --init --recursive
@@ -26,7 +26,7 @@ To make edits to the design, please send pull requests against the spec (`spec/s
 
 ## Examples
 
-The w3c web mobile group have defined a [series of use-cases where ServiceWorker is particularly useful](https://github.com/w3c-webmob/ServiceWorkersDemos). You can help by adding more use cases, draft implementation code, or even working examples once browsers support the required APIs.
+The W3C Web Mobile Group have defined a [series of use-cases where ServiceWorker is particularly useful](https://github.com/w3c-webmob/ServiceWorkersDemos). You can help by adding more use cases, draft implementation code, or even working examples once browsers support the required APIs.
 
 
 ## About labels and milestones on issues
@@ -38,12 +38,12 @@ This is to explain how we use labels and milestones to triage the issues. Note: 
 
 **milestone**: is used to mark issues we agreed to get done in principle by a given revision. For the sake of efficiency, we tend to only focus on the current milestone and leave everything else without specific milestones.
 
-**impacts MVP**: is used to mark issues impacting the "Minimal Viable Product". The MVP is the minimal scope of API that can solve actual use cases. These issues have the highest priority.
+**impacts MVP**: is used to mark issues impacting the “Minimal Viable Product”. The MVP is the minimal scope of API that can solve actual use cases. These issues have the highest priority.
 
-*Risk labels for impacts MVP issues*  
-**medium risk**: to further refine the "impacts MVP" issues. It indicates that the issue is moderately complex and that reaching a conclusion might take some time. These are of higher priority than issues with no risk label but are of lower priority than issues with a "high risk" label.
+*Risk labels for impacts MVP issues*
+**medium risk**: to further refine the “impacts MVP” issues. It indicates that the issue is moderately complex and that reaching a conclusion might take some time. These are of higher priority than issues with no risk label but are of lower priority than issues with a “high risk” label.
 
-**high risk**: to further refine the "impacts MVP" issues. It indicates that the issue is significantly complex and that reaching a conclusion might take a lot of time and effort. These are of higher priority than issues with no risk label or a "medium risk" label.
+**high risk**: to further refine the “impacts MVP” issues. It indicates that the issue is significantly complex and that reaching a conclusion might take a lot of time and effort. These are of higher priority than issues with no risk label or a “medium risk” label.
 
 
 
@@ -54,7 +54,7 @@ This is to explain how we use labels and milestones to triage the issues. Note: 
 
 **decided**: to record that a decision has been made.
 
-**invalid**: when something doesn't constitute a valid issue.
+**invalid**: when something doesn’t constitute a valid issue.
 
 **wontfix**: a decision has been made not to pursue this issue further.
 
@@ -67,8 +67,8 @@ This is to explain how we use labels and milestones to triage the issues. Note: 
 
 **fetch**: relates to Fetch
 
-**lifecycle**: relates to lifecycle aspects of Service Worker
+**lifecycle**: relates to lifecycle aspects of service worker
 
 **cache**: relevant to the Cache APIs
 
-**question**: not an actual issue. Items that have been filed in order to gain a better understanding of Service Worker.
+**question**: not an actual issue. Items that have been filed in order to gain a better understanding of service worker.

--- a/explainer.md
+++ b/explainer.md
@@ -1,36 +1,36 @@
-# ServiceWorkers Explained
+# Service workers explained
 
-## What's All This Then?
+## What’s all this then?
 
-Service Workers are being developed to answer frequent questions and concerns about the web platform, including:
+Service workers are being developed to answer frequent questions and concerns about the web platform, including:
 
  * An inability to explain (in the [Extensible Web Manifesto](https://extensiblewebmanifesto.org/) sense) HTTP caching and high-level HTTP interactions like the HTML5 AppCache
  * Difficulty in building offline-first web applications in a natural way
  * The lack of a background execution context which many proposed capabilities could make use of
 
-We also note that the long lineage of declarative-only solutions ([Google Gears, [Dojo Offline](http://www.sitepen.com/blog/category/dojo-offline/), and [HTML5 AppCache](http://alistapart.com/article/application-cache-is-a-douchebag)) have failed to deliver on their promise. Each successive declarative-only approach failed in many of the same ways, so the Service Worker effort has taken a different design approach: a largely-imperative system that puts developers firmly in control.
+We also note that the long lineage of declarative-only solutions ([Google Gears, [Dojo Offline](http://www.sitepen.com/blog/category/dojo-offline/), and [HTML5 AppCache](http://alistapart.com/article/application-cache-is-a-douchebag)) have failed to deliver on their promise. Each successive declarative-only approach failed in many of the same ways, so the service worker effort has taken a different design approach: a largely-imperative system that puts developers firmly in control.
 
-The ServiceWorker is like a [SharedWorker](https://html.spec.whatwg.org/multipage/workers.html#sharedworker) in that it:
+The service worker is like a [shared worker](https://html.spec.whatwg.org/multipage/workers.html#sharedworker) in that it:
 
 * Runs in its own global script context (usually in its own thread)
-* Isn't tied to a particular page
+* Isn’t tied to a particular page
 * Has no DOM access
 
-Unlike a SharedWorker, it:
+Unlike a shared worker, it:
 
 * Can run without any page at all
-* Can terminate when it isn't in use, and run again when needed (e.g., it's event-driven)
+* Can terminate when it isn’t in use, and run again when needed (e.g., it’s event-driven)
 * Has a defined upgrade model
 * Is HTTPS only (more on that in a bit)
 
-We can use ServiceWorker:
+We can use service workers:
 
 * To make sites work [faster and/or offline](https://www.youtube.com/watch?v=px-J9Ghvcx4) using network intercepting
-* As a basis for other 'background' features such as [push messaging](http://updates.html5rocks.com/2015/03/push-notificatons-on-the-open-web) and [background synchronization](https://github.com/slightlyoff/BackgroundSync/blob/master/explainer.md)
+* As a basis for other ‘background’ features such as [push messaging](http://updates.html5rocks.com/2015/03/push-notificatons-on-the-open-web) and [background synchronization](https://github.com/slightlyoff/BackgroundSync/blob/master/explainer.md)
 
-## Getting Started
+## Getting started
 
-First you need to register for a ServiceWorker:
+First you need to register for a service worker:
 
 ```js
 if ('serviceWorker' in navigator) {
@@ -44,21 +44,21 @@ if ('serviceWorker' in navigator) {
 }
 ```
 
-In this example, `/my-app/sw.js` is the location of the ServiceWorker script, and it controls pages whose URL begins `/my-app/`. The scope is optional, and defaults to `/`.
+In this example, `/my-app/sw.js` is the location of the service worker script, and it controls pages whose URL begins `/my-app/`. The scope is optional, and defaults to `/`.
 
-`.register` returns a promise. If you're new to promises, check out the [HTML5Rocks article](http://www.html5rocks.com/en/tutorials/es6/promises/).
+`.register` returns a promise. If you’re new to promises, check out the [HTML5Rocks article](http://www.html5rocks.com/en/tutorials/es6/promises/).
 
 Some restrictions:
 
 * The registering page must have been served securely (HTTPS without cert errors)
-* The ServiceWorker script must be on the same origin as the page, although you can import scripts from other origins using [`importScripts`](https://html.spec.whatwg.org/multipage/workers.html#apis-available-to-workers:dom-workerglobalscope-importscripts)
+* The service worker script must be on the same origin as the page, although you can import scripts from other origins using [`importScripts`](https://html.spec.whatwg.org/multipage/workers.html#apis-available-to-workers:dom-workerglobalscope-importscripts)
 * …as must the scope
 
 ### HTTPS only you say?
 
-Using ServiceWorker you can hijack connections, respond differently, & filter responses. Powerful stuff. While you would use these powers for good, a man-in-the-middle might not. To avoid this, you can only register for ServiceWorkers on pages served over HTTPS, so we know the ServiceWorker the browser receives hasn't been tampered with during its journey through the network.
+Using service workers you can hijack connections, respond differently, & filter responses. Powerful stuff. While you would use these powers for good, a man-in-the-middle might not. To avoid this, you can only register for service workers on pages served over HTTPS, so we know the service worker the browser receives hasn’t been tampered with during its journey through the network.
 
-Github Pages are served over HTTPS, so they're a great place to host demos.
+GitHub Pages are served over HTTPS, so they’re a great place to host demos.
 
 ## Initial lifecycle
 
@@ -82,17 +82,17 @@ self.addEventListener('activate', function(event) {
 });
 ```
 
-You can pass a promise to `event.waitUntil` to extend the installation process. Once `activate` fires, your ServiceWorker can control pages!
+You can pass a promise to `event.waitUntil` to extend the installation process. Once `activate` fires, your service worker can control pages!
 
-## So I'm controlling pages now?
+## So I’m controlling pages now?
 
-Well, not quite. A document will pick a ServiceWorker to be its controller when it navigates, so the document you called `.register` from isn't being controlled, because there wasn't a ServiceWorker there when it first loaded.
+Well, not quite. A document will pick a service worker to be its controller when it navigates, so the document you called `.register` from isn’t being controlled, because there wasn’t a service worker there when it first loaded.
 
-If you refresh the document, it'll be under the ServiceWorker's control. You can check `navigator.serviceWorker.controller` to see which ServiceWorker is in control, or `null` if there isn't one. Note: when you're updating from one ServiceWorker to another, things work a little differently, we'll get onto that in the "Updating" section.
+If you refresh the document, it’ll be under the service worker’s control. You can check `navigator.serviceWorker.controller` to see which service worker is in control, or `null` if there isn’t one. Note: when you’re updating from one service worker to another, things work a little differently, we’ll get onto that in the “Updating” section.
 
-If you shift+reload a document it'll always load without a controller, which is handy for testing quick CSS & JS changes.
+If you shift+reload a document it’ll always load without a controller, which is handy for testing quick CSS & JS changes.
 
-Documents tend to live their whole life with a particular ServiceWorker, or none at all. However, a ServiceWorker can call `self.skipWaiting()` ([spec](https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#service-worker-global-scope-skipwaiting)) to do an immediate takeover of all pages within scope.
+Documents tend to live their whole life with a particular service worker, or none at all. However, a service worker can call `self.skipWaiting()` ([spec](https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#service-worker-global-scope-skipwaiting)) to do an immediate takeover of all pages within scope.
 
 ## Network intercepting
 
@@ -104,14 +104,14 @@ self.addEventListener('fetch', function(event) {
 
 You get fetch events for:
 
-* Navigations within your ServiceWorker's scope
-* Any requests triggered by those pages, even if they're to another origin
+* Navigations within your service worker’s scope
+* Any requests triggered by those pages, even if they’re to another origin
 
 This means you get to hear about requests for the page itself, the CSS, JS, images, XHR, beacons… all of it. The exceptions are:
 
-* iframes & `<object>`s - these will pick their own controller based on their resource URL
-* ServiceWorkers - requests to fetch/update a ServiceWorker don't go through the ServiceWorker
-* Requests triggered within a ServiceWorker - you'd get a loop otherwise
+* iframes & `<object>`s – these will pick their own controller based on their resource URL
+* service workers – requests to fetch/update a service worker don’t go through the service worker
+* Requests triggered within a service worker – you’d get a loop otherwise
 
 The `request` object gives you information about the request such as its URL, method & headers. But the really fun bit, is you can hijack it and respond differently:
 
@@ -121,9 +121,9 @@ self.addEventListener('fetch', function(event) {
 });
 ```
 
-[Here's a live demo](https://jakearchibald.github.io/isserviceworkerready/demos/manual-response/).
+[Here’s a live demo](https://jakearchibald.github.io/isserviceworkerready/demos/manual-response/).
 
-`.respondWith` takes a `Response` object or a promise that resolves to one. We're creating a manual response above. The `Response` object comes from the [Fetch Spec](https://fetch.spec.whatwg.org/#response-class). Also in the spec is the `fetch()` method, which returns a promise for a response, meaning you can get your response from elsewhere:
+`.respondWith` takes a `Response` object or a promise that resolves to one. We’re creating a manual response above. The `Response` object comes from the [Fetch Spec](https://fetch.spec.whatwg.org/#response-class). Also in the spec is the `fetch()` method, which returns a promise for a response, meaning you can get your response from elsewhere:
 
 ```js
 self.addEventListener('fetch', function(event) {
@@ -137,9 +137,9 @@ self.addEventListener('fetch', function(event) {
 });
 ```
 
-In the above, I'm capturing requests that end `.jpg` and instead responding with a Google doodle. `fetch()` requests are CORS by default, but by setting `no-cors` I can use the response even if it doesn't have CORS access headers (although I can't access the content with JavaScript). [Here's a demo of that](https://jakearchibald.github.io/isserviceworkerready/demos/img-rewrite/).
+In the above, I’m capturing requests that end `.jpg` and instead responding with a Google doodle. `fetch()` requests are CORS by default, but by setting `no-cors` I can use the response even if it doesn’t have CORS access headers (although I can’t access the content with JavaScript). [Here’s a demo of that](https://jakearchibald.github.io/isserviceworkerready/demos/img-rewrite/).
 
-Promises let you fallback from one method to another:
+Promises let you fall back from one method to another:
 
 ```js
 self.addEventListener('fetch', function(event) {
@@ -151,15 +151,15 @@ self.addEventListener('fetch', function(event) {
 });
 ```
 
-The ServiceWorker comes with a cache API, making it easy to store responses for reuse later, more on that shortly, but first…
+The service worker comes with a cache API, making it easy to store responses for reuse later, more on that shortly, but first…
 
-## Updating a ServiceWorker
+## Updating a service worker
 
-The lifecycle of a ServiceWorker is based on Chrome's update model: Do as much as possible in the background, don't disrupt the user, complete the update when the current version closes.
+The lifecycle of a service worker is based on Chrome’s update model: do as much as possible in the background, don’t disrupt the user, complete the update when the current version closes.
 
-Whenever you navigate to page within scope of your ServiceWorker, the browser checks for updates in the background. If the script is byte-different, it's considered to be a new version, and installed (note: only the script is checked, not external `importScripts`). However, the old version remains in control over pages until all tabs using it are gone (unless `.replace()` is called during install). Then the old version is garbage collected and the new version takes over.
+Whenever you navigate to page within scope of your service worker, the browser checks for updates in the background. If the script is byte-different, it’s considered to be a new version, and installed (note: only the script is checked, not external `importScripts`). However, the old version remains in control over pages until all tabs using it are gone (unless `.replace()` is called during install). Then the old version is garbage collected and the new version takes over.
 
-This avoids the problem of two versions of a site running at the same time, in different tabs. Our current strategy for this is ["cross fingers, hope it doesn't happen"](https://twitter.com/jaffathecake/status/502779501936652289).
+This avoids the problem of two versions of a site running at the same time, in different tabs. Our current strategy for this is [“cross fingers, hope it doesn’t happen”](https://twitter.com/jaffathecake/status/502779501936652289).
 
 Note: Updates obey the freshness headers of the worker script (such as `max-age`), unless the `max-age` is greater than 24 hours, in which case it is capped to 24 hours.
 
@@ -181,15 +181,15 @@ self.addEventListener('activate', function(event) {
 });
 ```
 
-Here's [how that looks in practice](https://www.youtube.com/watch?v=VEshtDMHYyA).
+Here’s [how that looks in practice](https://www.youtube.com/watch?v=VEshtDMHYyA).
 
-Unfortunately refreshing a single tab isn't enough to allow an old worker to be collected and a new one take over. Browsers make the next page request before unloading the current page, so there isn't a moment when current active worker can be released.
+Unfortunately refreshing a single tab isn’t enough to allow an old worker to be collected and a new one take over. Browsers make the next page request before unloading the current page, so there isn’t a moment when current active worker can be released.
 
 The easiest way at the moment is to close & reopen the tab (cmd+w, then cmd+shift+t on Mac), or shift+reload then normal reload.
 
-## The Cache
+## The cache
 
-ServiceWorker comes with a [caching API](https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#cache-objects), letting you create stores of responses keyed by request.
+service worker comes with a [caching API](https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#cache-objects), letting you create stores of responses keyed by request.
 
 ```js
 self.addEventListener('install', function(event) {
@@ -217,11 +217,11 @@ self.addEventListener('fetch', function(event) {
 
 Matching within the cache is similar to the browser cache. Method, URL and vary headers are taken into account, but freshness headers are ignored. Things are only removed from caches when you remove them.
 
-You can add individual items to the cache with `cache.put(request, response)`, including ones you've created yourself. You can also control matching, [discounting things](https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#cache-query-options-dictionary) such as query string, methods, and vary headers.
+You can add individual items to the cache with `cache.put(request, response)`, including ones you’ve created yourself. You can also control matching, [discounting things](https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#cache-query-options-dictionary) such as query string, methods, and vary headers.
 
-## Other ServiceWorker related specifications
+## Other service worker–related specifications
 
-Since ServiceWorkers can spin up in time for events, they've opened up the possibility for other features that happen occasionally in the background, even when the page isn't open. Such as:
+Since service workers can spin up in time for events, they’ve opened up the possibility for other features that happen occasionally in the background, even when the page isn’t open. Such as:
 
 * [Push](http://w3c.github.io/push-api/)
 * [Background sync](https://github.com/slightlyoff/BackgroundSync)
@@ -229,9 +229,9 @@ Since ServiceWorkers can spin up in time for events, they've opened up the possi
 
 ## Conclusions
 
-This document only scratches the surface of what ServiceWorkers enable, and aren't an exhaustive list of all of the available APIs available to controlled pages or ServiceWorker instances. Nor does it cover emergent practices for authoring, composing, and upgrading applications architected to use ServiceWorkers. It is, hopefully, a guide to understanding the promise of ServiceWorkers and the rich promise of offline-by-default web applications that are URL friendly and scalable.
+This document only scratches the surface of what service workers enable, and aren’t an exhaustive list of all of the available APIs available to controlled pages or service worker instances. Nor does it cover emergent practices for authoring, composing, and upgrading applications architected to use service workers. It is, hopefully, a guide to understanding the promise of service workers and the rich promise of offline-by-default web applications that are URL friendly and scalable.
 
 ## Acknowledgments
 
-Many thanks to [Web Personality of the Year nominee](http://www.ubelly.com/thecritters/) Jake ("B.J.") Archibald, David Barrett-Kahn, Anne van Kesteren, Michael Nordman, Darin Fisher, Alec Flett, Andrew Betts, Chris Wilson, Aaron Boodman, Dave Herman, Jonas Sicking, and Greg Billock for their comments and contributions to this document and to the discussions that have informed it.
+Many thanks to [Web Personality of the Year nominee](http://www.ubelly.com/thecritters/) Jake (“B.J.”) Archibald, David Barrett-Kahn, Anne van Kesteren, Michael Nordman, Darin Fisher, Alec Flett, Andrew Betts, Chris Wilson, Aaron Boodman, Dave Herman, Jonas Sicking, and Greg Billock for their comments and contributions to this document and to the discussions that have informed it.
 

--- a/implementation_considerations.md
+++ b/implementation_considerations.md
@@ -1,30 +1,30 @@
-# Implementation Considerations for Service Workers
+# Implementation considerations for service workers
 
 Or
 
-### _What to Expect When You're Expecting to Implement_
+### _What to expect when you’re expecting to implement_
 
-So you've got a browser engine, are looking into this whole "Service Workers" thing and have some questions. Take heart, dear reader! Your friendly spec designers/authors are here to answer your (anticipated) questions. Want more answers? [File a bug](issues) and tag it `implementation-concern`.
+So you’ve got a browser engine, are looking into this whole "Service Workers" thing and have some questions. Take heart, dear reader! Your friendly spec designers/authors are here to answer your (anticipated) questions. Want more answers? [File a bug](issues) and tag it `implementation-concern`.
 
-This doc looks first at key concepts then outlines the [areas of helpful built-in ambiguity ](//slightlyoff.github.io/ServiceWorker/spec/service_worker/) that provide opportunities to go fast. Each opportunity includes a list of strategies that implementations might explore to improve Service Worker performance.
+This doc looks first at key concepts then outlines the [areas of helpful built-in ambiguity ](https://slightlyoff.github.io/ServiceWorker/spec/service_worker/) that provide opportunities to go fast. Each opportunity includes a list of strategies that implementations might explore to improve service worker performance.
 
-## Key Concepts
+## Key concepts
 
-### Event-Driven Workers
+### Event-driven workers
 
-The biggest thing to understand about Service Workers is that they are _event driven_. Unlike other forms of [Web Worker](http://www.w3.org/TR/workers/), the lifetime of the script execution context of the worker is not related to documents which have handles to the worker. Instead, Service Workers begin life when events are sent to them, and they can end between events.
+The biggest thing to understand about service workers is that they are _event driven_. Unlike other forms of [Web Worker](http://www.w3.org/TR/workers/), the lifetime of the script execution context of the worker is not related to documents which have handles to the worker. Instead, service workers begin life when events are sent to them, and they can end between events.
 
-The most performance-sensitive of these events is the `fetch` event for top-level document navigation. To ensure that the decision regarding which (if any) Service Worker to boot up to handle a `fetch` event, the spec uses a static tuple of origin + URL pattern to map SW's to navigations. This list will change infrequently and is likely to be something you can cache in memory for fast lookup.
+The most performance-sensitive of these events is the `fetch` event for top-level document navigation. To ensure that the decision regarding which (if any) service worker to boot up to handle a `fetch` event, the spec uses a static tuple of origin + URL pattern to map service workers to navigations. This list will change infrequently and is likely to be something you can cache in memory for fast lookup.
 
-Once a Service Worker is a match for a particular navigation, a Service Worker instance is created (if one isn't already running) using the previously cached scripts. It's reasonable to assume that all of the scripts required to start the worker will be in the local cache at this point, so there's little reason to worry about network speed or flakiness here (disk flakiness is another question entirely, see "Racing Allowed" below).
+Once a service worker is a match for a particular navigation, a Service Worker instance is created (if one isn’t already running) using the previously cached scripts. It’s reasonable to assume that all of the scripts required to start the worker will be in the local cache at this point, so there’s little reason to worry about network speed or flakiness here (disk flakiness is another question entirely, see “Racing Allowed” below).
 
-Next, an event is dispatched to the now-running worker. If the worker's event handler doesn't call `e.respondWith()`, no further script is implicated in servicing the fetch and normal resource loading can proceed as per usual. If the worker _does_ take a crack at responding to the event, the worker's life is typically extended to enable it to do whatever work it needs to do to respond (asynchronously, via the `Promise` provided to `respondWith()`) . Once the worker is done handling the event (or not), the UA _is free to shut the worker down_ and only revive it again for the next event.
+Next, an event is dispatched to the now-running worker. If the worker’s event handler doesn’t call `e.respondWith()`, no further script is implicated in servicing the fetch and normal resource loading can proceed as per usual. If the worker _does_ take a crack at responding to the event, the worker’s life is typically extended to enable it to do whatever work it needs to do to respond (asynchronously, via the `Promise` provided to `respondWith()`) . Once the worker is done handling the event (or not), the UA _is free to shut the worker down_ and only revive it again for the next event.
 
-It bears repeating: if no event's lifecycle is keeping the SW alive, UA's can shut them down and reclaim whatever resources they might have been using. If this doesn't warm your cold, cold implementer's heart then you might truly be dead inside. The opportunities to trade space for speed (and vice versa) are massive. The freedom to start and end SWs at a time of your choosing is the stuff good optimization strategies are made off.
+It bears repeating: if no event’s lifecycle is keeping the service worker alive, UAs can shut them down and reclaim whatever resources they might have been using. If this doesn’t warm your cold, cold implementer’s heart then you might truly be dead inside. The opportunities to trade space for speed (and vice versa) are massive. The freedom to start and end service workers at a time of your choosing is the stuff good optimization strategies are made off.
 
 ### Install
 
-Installation of SWs happens as a result of a document calling:
+Installation of service workers happens as a result of a document calling:
 
 ```html
 <!-- https://example.com/index.html -->
@@ -33,115 +33,115 @@ Installation of SWs happens as a result of a document calling:
 </script>
 ```
 
-The SW might be homunculus...dozens of imports, loads of code. This is the web and every terrible thing that authors _can_ do _will_ be done. This looks bad, right?
+The service worker might be homunculus… dozens of imports, loads of code. This is the web and every terrible thing that authors _can_ do _will_ be done. This looks bad, right?
 
-Turns out that SWs have a defined lifecycle that enables us to think about installation as a separate, asynchronous, potentially long-running phase that _doesn't affect the rest of `index.html`_'s loading process.
+Turns out that service workers have a defined lifecycle that enables us to think about installation as a separate, asynchronous, potentially long-running phase that _doesn’t affect the rest of `index.html`_’s loading process.
 
-Installation can be low-priority, and no documents will be controlled by the SW until it succeeds. That means that it's possible to depend on lots of script and cache many resources in an SW without worrying about the "load time" of the SW itself since all subsequent starts of the SW will come from local disk cache.
+Installation can be low-priority, and no documents will be controlled by the service worker until it succeeds. That means that it’s possible to depend on lots of script and cache many resources in an service worker without worrying about the “load time” of the service worker itself since all subsequent starts of the service worker will come from local disk cache.
 
 ### Event Dispatch
 
-SWs lean on the DOM Events as the entry point for nearly all work. The contract that developers must learn is that they must call `e.waitUntil()` or `e.respondWith()` to lengthen the life of the overall operation. All of the APIs available to them are asynchronous, and the combination of these factors implies that SWs are meant to be async by default. The tools at hand lead developers down this path, and cooperative multi-tasking (à la node.js) is the way that libraries must be structured, both for performance and to work naturally with the SW execution model. Lastly, remember that developers can move work off-thread using sub-workers. They'll also be killed along with their parent SWs, but long-running or CPU intensive work that might otherwise cause potential for becoming unresponsive can be delegated to contexts which will not block the SW thread.
+Service workers lean on the DOM Events as the entry point for nearly all work. The contract that developers must learn is that they must call `e.waitUntil()` or `e.respondWith()` to lengthen the life of the overall operation. All of the APIs available to them are asynchronous, and the combination of these factors implies that service workers are meant to be async by default. The tools at hand lead developers down this path, and cooperative multi-tasking (à la Node.js) is the way that libraries must be structured, both for performance and to work naturally with the service worker execution model. Lastly, remember that developers can move work off-thread using sub-workers. They’ll also be killed along with their parent service workers, but long-running or CPU intensive work that might otherwise cause potential for becoming unresponsive can be delegated to contexts which will not block the service worker thread.
 
-## Good News, Everybody!
+## Good news, everybody!
 
-SWs are designed to enable many optimizations. This section covers some of these opportunities and outlines potential strategies for exploiting them.
+Service workers are designed to enable many optimizations. This section covers some of these opportunities and outlines potential strategies for exploiting them.
 
 _Caveat Emptor_: This document was drafted in early 2014. Architectures and constraints change. The set of areas to consider outlined here is influenced by a lack perfect foreknowledge. Memory and IO might become free. CPU might become expensive. Genetically engineered super-intelligent catdog hybrids may take over the world. YMMV.
 
-### Only Matching Navigations Boot SW's
+### Only matching navigations boot service workers
 
-Lets say `example.com` has a SW registered and `acme.com` embeds the image `https://example.com/images/kittens.gif`. Since the SW matching algorithm is primarily based on _navigations_ and not sub-resource requests, a visit to `acme.com` will _not_ boot the SW for `example.com` for this fetch. Instead, the `onfetch` event is sent to the `acme.com` SW (if there is one).
+Lets say `example.com` has a service worker registered and `acme.com` embeds the image `https://example.com/images/kittens.gif`. Since the service worker matching algorithm is primarily based on _navigations_ and not sub-resource requests, a visit to `acme.com` does _not_ boot the service worker for `example.com` for this fetch. Instead, the `onfetch` event is sent to the `acme.com` service worker (if there is one).
 
-The need to match navigations may still strike you as a performance burden, but there's reason for hope. First, you're already matching a likely-larger list to provide `:visited` metadata to renderers. Next, the globbing format is designed to be simple to speed matches. Lastly, since a UA may skip a SW entirely, it's feasible for a UA to only match against some set of registered SWs (say, the most recently installed or used).
+The need to match navigations may still strike you as a performance burden, but there’s reason for hope. First, you’re already matching a likely-larger list to provide `:visited` metadata to renderers. Next, the globbing format is designed to be simple to speed matches. Lastly, since a UA may skip a service worker entirely, it’s feasible for a UA to only match against some set of registered service workers (say, the most recently installed or used).
 
-UAs may even decide to try harder (match against a larger list of SWs) when offline to help provide a better offline experience.
+UAs may even decide to try harder (match against a larger list of service workers) when offline to help provide a better offline experience.
 
 #### Strategies
 
   * __Keep the match list in memory__
   * __Memory-bound the size of the match list__
-  * __Only run matching test against top-level navigations__. Sub-resource requests are always sent to the SW that controls the page (if any) and so don't need to be matched. Only top-level navigations every need to be sent through the matching algorithm.
+  * __Only run matching test against top-level navigations__. Sub-resource requests are always sent to the service worker that controls the page (if any) and so don’t need to be matched. Only top-level navigations every need to be sent through the matching algorithm.
 
 
-### Events Implicitly Filter
+### Events implicitly filter
 
-Only the event handlers registered at the top-level evaluation of the first evaluation (at install time) of a version of a SW script are guaranteed to be dispatched against in the future. That is to say, if a SW script doesn't register an `onfetch` handler _you can avoid ever sending it `fetch` events_. This is a powerful mechanism for trimming the number of times you need to do potentially expensive work by invoking SWs.
+Only the event handlers registered at the top-level evaluation of the first evaluation (at install time) of a version of a service worker script are guaranteed to be dispatched against in the future. That is to say, if a service worker script doesn’t register an `onfetch` handler _you can avoid ever sending it `fetch` events_. This is a powerful mechanism for trimming the number of times you need to do potentially expensive work by invoking service workers.
 
 #### Strategies
 
   * __Prune the navigation match list based on `onfetch` handlers__
-  * __Warn SW authors that use APIs which would need corresponding handlers which are not registered__. E.g., a call to `navigator.requestSync()` against a SW that doesn't include an `onsync` handler isn't likely to be what the author meant to do.
+  * __Warn service worker authors that use APIs which would need corresponding handlers which are not registered__. E.g., a call to `navigator.requestSync()` against a service worker that doesn’t include an `onsync` handler isn’t likely to be what the author meant to do.
 
-### Startup _Matters_
+### Startup _matters_
 
-The performance of evaluation of the Service Worker script is a key bottleneck to address in ensuring that perceived latency of SW-controlled documents remains low. It isn't possible to send the `fetch` event to the worker until it has been evaluated, potentially including code (via `importScripts()`) from other files.
-
-#### Strategies
-
-  * __Fetch SWs from disk early__. Links in documents to SW-controlled space constitute one of perhaps many available signals about the likelihood that the next navigation will be to space controlled by a SW. As discussed in the matching section, querying to understand if a navigation will match a SW should be made cheap and, therefore, it's possible to imagine that optimizing implementations may try to pre-fetch SW scripts from disk based on speculative matches; e.g. the user typing `microsoft.co` in the address bar is perhaps a strong signal that a frequent visitor of `microsoft.com` will want a registered SW for that origin to be available quickly. As with all speculative optimizations, the real work here is ensuring good hit rates.
-  * __Interpret__. JIT-only VMs (like V8) are at a startup-time disadvantage due to the time taken by JIT codegen. SW scripts aren't likely to be compute intensive (and if they are, your engine can detect as much and flag future runs for JITing). Simpler compilation strategies that get the handlers available faster are a good area to investigate inside the SW execution context.
-  * __Store SW scripts as a single unit__. Storage locality still matters, even in 2014. Commodity MLC flash latency is _atrocious_, and spinning disk isn't getting (much) faster. Since SW scripts will nearly always require their previously `importScripts()` dependencies (which will be cached as a group), it pays to store them in a format that reduces the number of seeks/reads necessary to get the SW started. Also, remember that install-time is async, so there is time/energy available to optimize the storage layout up-front.
-  * __Cache Parse Trees or Snapshot__. SW scripts (and their dependencies) shouldn't change in a single version of the application. Combined with a reduced API surface area, it's possible to apply more exotic strategies for efficiently "rehydrating" the startup execution context of the SW. The spec makes no guarantees about how frequently a SW context is killed and re-evaluated in relationship to the number of overall events dispatched, so a UA is free to make non-side-effecting global startup appear to be a continuation of a previous execution.
-  * __Warn on nondeterministic imports__. SWs are likely to be invoked when offline. This means that any scripts included via `importScripts()` that aren't from stable URLs _are likely to break when offline_. UAs can help keep developers on the optimization-friendly path by warning at the console whenever a call to `importScripts()` occurs at a location other than the top-level or is based on a non-static string value.
-  * __Warn on non-trivial global work__. Since SWs "pay" for any globally executed code every time they start, it's a good idea for implementations to *_STRONGLY_* discourage doing work outside the defined lifecycle events (`oninstall` and `onactivate`).
-  * __Learn storage/DB patterns__. SW's are going to need to lean on IDB for state keeping across invocations and `Cache` objects for dealing with HTTP responses. In both cases it's possible to observe the set of resources most frequently accessed by a particular version of a SW and work to ensure that they're cheaply available by the time the SW is sent a particular event. In particular, speculatively fetching indexes may pay off in some scenarios.
-  * __Delay shutdown__. The cheapest SW to start is the one you haven't killed. Optimizing implementations may consider providing a 'grace period' for the shutdown of SW threads to reduce startup time of subsequent events. This strategy can be further refined with semantic awareness about event types. E.g., a top-level navigation to a SW is _likely_ to generate sub-resource fetch events soon after. Shutting down the original SW execution context quickly may be wasteful.
-
-### It's All Async
-
-Aside from `importScripts()`, no synchronous APIs are available to SWs. This is by design. Remaining responsive from the shared SW context requires ensuring that decisions are made quickly and long-running work can be deferred to underlying (asynchronous) systems. No API will be added to the SW execution context that can potentially create cross-context mutex holds (e.g., Local Storage) or otherwise block (e.g., synchronous XHR). This discipline makes it simpler to reason about what it means to be a poorly-written SW script.
+The performance of evaluation of the service worker script is a key bottleneck to address in ensuring that perceived latency of service worker–controlled documents remains low. It isn’t possible to send the `fetch` event to the worker until it has been evaluated, potentially including code (via `importScripts()`) from other files.
 
 #### Strategies
 
-  * __Prioritize the SW thread__. SW execution is likely to be a sensitive component of overall application performance. Ensure it isn't getting unscheduled!
-  * __Warn on long periods of SW-thread work__. Remaining responsive requires yielding to the SW thread's event loop. DevTools can provide value by warning developers of long periods of potentially-blocking work that might reduce responsiveness to incoming events. A reasonable, mobile-friendly starting point might be to warn on any function that takes longer than 20ms to return in the fast path (e.g., `onfetch` or `onmessage`). Recommend to users that they move long-running work to sub-workers, to other turns (via new promises), or that they cache expensive work such that it can be returned via an async API (e.g. IDB).
-  * __Plan features with async in mind__. As you plan to add new features to the platform that you'd like to have exposed to the SW context, remember that they'll need to pass the "async only" test. Using Promises is a good first place to start, and reaching out to the editors of the SW spec early can't hurt.
+  * __Fetch service workers from disk early__. Links in documents to service worker–controlled space constitute one of perhaps many available signals about the likelihood that the next navigation will be to space controlled by a service worker. As discussed in the matching section, querying to understand if a navigation will match a service worker should be made cheap and, therefore, it’s possible to imagine that optimizing implementations may try to pre-fetch service worker scripts from disk based on speculative matches; e.g. the user typing `microsoft.co` in the address bar is perhaps a strong signal that a frequent visitor of `microsoft.com` will want a registered service worker for that origin to be available quickly. As with all speculative optimizations, the real work here is ensuring good hit rates.
+  * __Interpret__. JIT-only VMs (like V8) are at a startup-time disadvantage due to the time taken by JIT codegen. Service worker scripts aren’t likely to be computation-intensive (and if they are, your engine can detect as much and flag future runs for JITing). Simpler compilation strategies that get the handlers available faster are a good area to investigate inside the service worker execution context.
+  * __Store service worker scripts as a single unit__. Storage locality still matters, even in 2014. Commodity MLC flash latency is _atrocious_, and spinning disk isn’t getting (much) faster. Since service worker scripts nearly always require their previous `importScripts()` dependencies (which are cached as a group), it pays to store them in a format that reduces the number of seeks/reads necessary to get the service worker started. Also, remember that install-time is async, so there is time/energy available to optimize the storage layout up-front.
+  * __Cache parse trees or snapshot__. Service worker scripts (and their dependencies) shouldn’t change in a single version of the application. Combined with a reduced API surface area, it’s possible to apply more exotic strategies for efficiently “rehydrating” the startup execution context of the service worker. The spec makes no guarantees about how frequently a service worker context is killed and re-evaluated in relationship to the number of overall events dispatched, so a UA is free to make non-side-effecting global startup appear to be a continuation of a previous execution.
+  * __Warn on nondeterministic imports__. Service workers are likely to be invoked when offline. This means that any scripts included via `importScripts()` that aren’t from stable URLs _are likely to break when offline_. UAs can help keep developers on the optimization-friendly path by warning at the console whenever a call to `importScripts()` occurs at a location other than the top-level or is based on a non-static string value.
+  * __Warn on non-trivial global work__. Since service workers “pay” for any globally executed code every time they start, it’s a good idea for implementations to *_STRONGLY_* discourage doing work outside the defined lifecycle events (`oninstall` and `onactivate`).
+  * __Learn storage/DB patterns__. Service workers are going to need to lean on IDB for state keeping across invocations and `Cache` objects for dealing with HTTP responses. In both cases it’s possible to observe the set of resources most frequently accessed by a particular version of a service worker and work to ensure that they’re cheaply available by the time the service worker is sent a particular event. In particular, speculatively fetching indexes may pay off in some scenarios.
+  * __Delay shutdown__. The cheapest service worker to start is the one you haven’t killed. Optimizing implementations may consider providing a “grace period” for the shutdown of service worker threads to reduce startup time of subsequent events. This strategy can be further refined with semantic awareness about event types. E.g., a top-level navigation to a service worker is _likely_ to generate sub-resource fetch events soon after. Shutting down the original service worker execution context quickly may be wasteful.
+
+### It’s all async
+
+Aside from `importScripts()`, no synchronous APIs are available to service workers. This is by design. Remaining responsive from the shared service worker context requires ensuring that decisions are made quickly and long-running work can be deferred to underlying (asynchronous) systems. No API will be added to the service worker execution context that can potentially create cross-context mutex holds (e.g., Local Storage) or otherwise block (e.g., synchronous XHR). This discipline makes it simpler to reason about what it means to be a poorly-written service worker script.
+
+#### Strategies
+
+  * __Prioritize the service worker thread__. Service worker execution is likely to be a sensitive component of overall application performance. Ensure it isn’t getting unscheduled!
+  * __Warn on long periods of service worker thread work__. Remaining responsive requires yielding to the service worker thread’s event loop. DevTools can provide value by warning developers of long periods of potentially-blocking work that might reduce responsiveness to incoming events. A reasonable, mobile-friendly starting point might be to warn on any function that takes longer than 20ms to return in the fast path (e.g., `onfetch` or `onmessage`). Recommend to users that they move long-running work to sub-workers, to other turns (via new promises), or that they cache expensive work such that it can be returned via an async API (e.g. IDB).
+  * __Plan features with async in mind__. As you plan to add new features to the platform that you’d like to have exposed to the service worker context, remember that they’ll need to pass the “async only” test. Using Promises is a good first place to start, and reaching out to the editors of the service worker spec early can’t hurt.
   * __Write async tests__. Your implementation is going to need to handle a large degree of variability in timing. Testing (and fuzzing) your scheduling behavior to optimize for overall app performance, particularly in the multiple-tab scenario, is key to keeping an eye on the real-world impact of performance tuning.
-  * __Get smart about return types__. When it comes to dealing in async responses, the word "return" is usually phrased as `e.respondWith()`. What's replied with is usually an instance of a `Promise` type, but _not all `Promise`s are created equal_. Consider the case of `e.respondWith(e.default())` and `e.respondWith(caches.match(e.request))`. Both return types result in a delegation to an underlying mechanism _with no further SW interaction_. Since no additional handlers are added to the vended Promise object, the receiving event can know that the SW is effectively out of the loop for the rest of the operation. This allows savvy implementations to avoid re-entering the SW and reifying `Response` objects in the SW execution context.
+  * __Get smart about return types__. When it comes to dealing in async responses, the word “return” is usually phrased as `e.respondWith()`. What’s replied with is usually an instance of a `Promise` type, but _not all `Promise`s are created equal_. Consider the case of `e.respondWith(e.default())` and `e.respondWith(caches.match(e.request))`. Both return types result in a delegation to an underlying mechanism _with no further service worker interaction_. Since no additional handlers are added to the vended `Promise` object, the receiving event can know that the service worker is effectively out of the loop for the rest of the operation. This allows savvy implementations to avoid re-entering the service worker and reifying `Response` objects in the service worker execution context.
 
-### Best Effort
+### Best effort
 
-UA's are free to _not_ start SW's for navigations (or other events), _event if they would match a registered and active SW_. If you find yourself under memory pressure or for some reason don't happen to think a SW is necessary or beneficial (e.g., it has previously been killed for abusing CPU, doesn't respond to requests in a timeline way, or habitually times out and has to be clobbered), the UA is _free to not start it for a given navigation_. This has the knock-on effect that the SW won't be consulted for sub-resource requests for the document either.
+UAs are free to _not_ start service worker for navigations (or other events), _event if they would match a registered and active service worker_. If you find yourself under memory pressure or for some reason don’t happen to think a service worker is necessary or beneficial (e.g., it has previously been killed for abusing CPU, doesn’t respond to requests in a timeline way, or habitually times out and has to be clobbered), the UA is _free to not start it for a given navigation_. This has the knock-on effect that the service worker won’t be consulted for sub-resource requests for the document either.
 
-UAs, obviously, should try to do their best to enable SWs to do _their_ best in serving meaningful content to users, and we recommend always trying to send sub-resource requests to SWs for documents that begin life based on the SW in question.
+UAs, obviously, should try to do their best to enable service workers to do _their_ best in serving meaningful content to users, and we recommend always trying to send sub-resource requests to service workers for documents that begin life based on the service worker in question.
 
 
-### Installation is Not in the Fast Path
+### Installation is not in the fast path
 
-The first page loaded from an application that calls `navigator.serviceWorker.register()` cannot, by definition, be served from the SW itself. This illuminates the async nature of SW installation. Because SW installation may take a long time (downloading imported scripts and populating `Cache` objects), the lifecycle events for the SW system are designed to allow authors to inform the UA of installation success.
+The first page loaded from an application that calls `navigator.serviceWorker.register()` cannot, by definition, be served from the service worker itself. This illuminates the async nature of service worker installation. Because service worker installation may take a long time (downloading imported scripts and populating `Cache` objects), the lifecycle events for the service worker system are designed to allow authors to inform the UA of installation success.
 
-Until installation success a registered SW _will not be sent any performance-sensitive events_. The async nature of installation provides an opportunity for implementations to do extra work to keep the fast-path responsive.
+Until installation success a registered service worker _will not be sent any performance-sensitive events_. The async nature of installation provides an opportunity for implementations to do extra work to keep the fast-path responsive.
 
 #### Strategies
 
-  * __Prioritize SW resource fetching appropriately__. It may improve performance of the installing document to prioritize resource fetches of the foreground page above those of the installing SW.
-  * __Do extra work to optimize SW loading before activation__. UAs have leeway to avoid activating the SW for navigations until they're good and ready to do so. Thinks is your chance to optimize the crud out of them.
+  * __Prioritize service worker resource fetching appropriately__. It may improve performance of the installing document to prioritize resource fetches of the foreground page above those of the installing service worker.
+  * __Do extra work to optimize service worker loading before activation__. UAs have leeway to avoid activating the service worker for navigations until they’re good and ready to do so. Thinks is your chance to optimize the crud out of them.
 
-### Racing Allowed
+### Racing allowed
 
 Anecdotal evidence suggests that commodity OSes and hardware perform VERY badly in disk I/O. Some systems are so degraded that local (valid) caches fetched from disk may perform worse than requests for equivalent resources from the network. Improvements in networks, the spread of malware, and the spread of poorly-written virus scanners exacerbate the underlying trend towards poorly performing disk I/O.
 
 #### Strategies
 
-  * __Learn to race on top-level navigations__. Adapting to historical (local) I/O performance may help UAs decide if and when to avoid using local resources. SWs may, at first glance, appear to muddy the waters, but fear not! Nothing about the SW spec forces an implementer to _always_ send navigations to a matching SW. In fact, the implementation can attempt to go to the network for a top-level navigation while concurrently attempting to dispatch an `onfetch` to the matching SW. Assuming the UA chooses to render the document produced by the winner of the race, the model from then on is clear. Thanks to the page-ownership model of the SW design, the first system to respond will "control" sub-resource requests. This means that if a SW is used, all subsequent sub-resource requests should be sent to the SW (not raced). If the network wins the race, all sub-resource requests will be sent to the network (not the SW).
-  * __Learn to disable SWs__. In extreme cases, if disk is degraded to the extent that SWs can never start quickly, it may be advantageous to simply disable the SW subsystem entirely. Thanks to the online-fallback model of SWs, applications should continue to function (to the extent that they can).
+  * __Learn to race on top-level navigations__. Adapting to historical (local) I/O performance may help UAs decide if and when to avoid using local resources. Service workers may, at first glance, appear to muddy the waters, but fear not! Nothing about the service worker spec forces an implementer to _always_ send navigations to a matching service worker. In fact, the implementation can attempt to go to the network for a top-level navigation while concurrently attempting to dispatch an `onfetch` to the matching service worker. Assuming the UA chooses to render the document produced by the winner of the race, the model from then on is clear. Thanks to the page-ownership model of the service worker design, the first system to respond will “control” sub-resource requests. This means that if a service worker is used, all subsequent sub-resource requests should be sent to the service worker (not raced). If the network wins the race, all sub-resource requests will be sent to the network (not the service worker).
+  * __Learn to disable service workers__. In extreme cases, if disk is degraded to the extent that service workers can never start quickly, it may be advantageous to simply disable the service worker subsystem entirely. Thanks to the online-fallback model of service workers, applications should continue to function (to the extent that they can).
 
-### Cache Objects Are HTTP-specific
+### Cache objects are HTTP-specific
 
-Objects in `self.caches` are instances of `Cache`. These HTTP-like-cache objects deal _exclusively_ in HTTP `Response` objects. With the exception of programmatic (not automatic) eviction these `Cache` objects are best thought of a group of native cache items. Most of the operations available for dealing with them will mirror HTTP cache query semantics and will likely be familiar to implementers. You know how to make this stuff fast.
+Objects in `self.caches` are instances of `Cache`. These HTTP-like-cache objects deal _exclusively_ in HTTP `Response` objects. With the exception of programmatic (not automatic) eviction these `Cache` objects are best thought of as a group of native cache items. Most of the operations available for dealing with them mirror HTTP cache query semantics and will likely be familiar to implementers. You know how to make this stuff fast.
 
 #### Strategies
 
   * __Store `Response` objects like HTTP cache entries__. It might be tempting to lean on IDB or other general-purpose storage for handling `Cache` entries. Browser HTTP caches have seen a decade+ of tuning for the specific use-case of returning HTTP data to renderers. It may be advantageous to lean on this engineering where possible.
 
-### Interaction With Prefetch and Prerender Is Sane
+### Interaction with prefetch and prerender is sane
 
-Speculative pre-parsing of documents and CSS resources (not blocking a parser on `<script>` elements, etc.) to locate URLs to speculatively load is an important browser optimization. SWs play well with this optimization since they conceptually sit "behind" the document but in front of the network layer. Sending `onfetch` events for these resources should happen in the usual way.
+Speculative pre-parsing of documents and CSS resources (not blocking a parser on `<script>` elements, etc.) to locate URLs to speculatively load is an important browser optimization. Service workers play well with this optimization since they conceptually sit “behind” the document but in front of the network layer. Sending `onfetch` events for these resources should happen in the usual way.
 
-Similarly, [pre-rendering](https://developers.google.com/chrome/whitepapers/prerender) requests should be sent to SWs. They can help warm-up documents while offline. A UA might decide to only send pre-render requests to URL space with a matching SW registration when offline to avoid wasting resources.
+Similarly, [pre-rendering](https://developers.google.com/chrome/whitepapers/prerender) requests should be sent to service workers. They can help warm-up documents while offline. A UA might decide to only send pre-render requests to URL space with a matching service worker registration when offline to avoid wasting resources.
 
 #### Strategies
 
-  * __Start DNS and TCP early__. It may improve overall performance to begin DNS resolution and TCP warm-up for prefetch-located resources _concurrently_ with dispatching the request to the SW. This, obviously, requires measurement (and perhaps adaption on a per-SW version basis) to verify that requests outbound from a SW usually correspond to the origin of the `Request` sent to the SW itself.
-  * __Pre-fetch to SW-controlled URL space when offline__. Pre-render is a huge boon to app performance when online, but generally isn't available offline. SWs can help by providing a "map" of the available world based on SW registrations with `onfetch` handlers.
+  * __Start DNS and TCP early__. It may improve overall performance to begin DNS resolution and TCP warm-up for prefetch-located resources _concurrently_ with dispatching the request to the service worker. This, obviously, requires measurement (and perhaps adaption on a per–service worker version basis) to verify that requests outbound from a service worker usually correspond to the origin of the `Request` sent to the service worker itself.
+  * __Pre-fetch to service worker–controlled URL space when offline__. Pre-render is a huge boon to app performance when online, but generally isn’t available offline. Service workers can help by providing a “map” of the available world based on service worker registrations with `onfetch` handlers.


### PR DESCRIPTION
To reduce confusion, this patch also ensures that sentence case is used consistently for titles.

Note: this only affects the Markdown files.

Ref. https://github.com/slightlyoff/ServiceWorker/issues/705.