### PR TITLE
Update for changes to HTML's script-fetching algorithms

### DIFF
--- a/spec/service_worker/index.bs
+++ b/spec/service_worker/index.bs
@@ -211,22 +211,17 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
             text: classic script
             text: creation url
             text: dom manipulation task source
-            text: fetch a classic worker script
-            text: fetch a module script tree
             text: fire a simple event
-            text: https state
+            text: https state; for: environment settings object
             text: module script
             text: realm execution context
             text: report the error
             text: run a classic script
             text: run a module script
             text: script; url: concept-script
-            text: set up the request; url: fetching-scripts-set-up-request
             text: task queue; for: event loop
-            text: process the response; url: fetching-scripts-process-response
         urlPrefix: workers.html
             text: get a fetch result
-            text: https state
             text: import scripts into worker global scope
             text: kill a worker
             text: postprocess the fetch result
@@ -328,7 +323,7 @@ spec: webidl; urlPrefix: https://heycam.github.io/webidl/
     <p>A <a href="#dfn-service-worker">service worker</a> has an associated <dfn id="dfn-service-worker-id">id</dfn> (an opaque string), which uniquely identifies itself during the lifetime of its <a href="#dfn-containing-service-worker-registration">containing service worker registration</a>.</p>
     <p>A <a href="#dfn-service-worker">service worker</a> is dispatched a set of <dfn id="dfn-lifecycle-events">lifecycle events</dfn>, <a href="#service-worker-global-scope-install-event">install</a> and <a href="#service-worker-global-scope-activate-event">activate</a>, and <dfn id="dfn-functional-events">functional events</dfn> including <a href="#service-worker-global-scope-fetch-event">fetch</a>.</p>
     <p>A <a href="#dfn-service-worker">service worker</a> has an associated <dfn id="dfn-script-resource">script resource</dfn> (a <a>script</a>), which represents its own script resource. It is initially set to null. A <a href="#dfn-script-resource">script resource</a> has an associated <dfn id="dfn-has-ever-been-evaluated-flag">has ever been evaluated flag</dfn>. It is initially unset. A <a href="#dfn-script-resource">script resource</a> has an associated <dfn id="dfn-https-state">HTTPS state</dfn> which is "<code>none</code>", "<code>deprecated</code>", or "<code>modern</code>". Unless stated otherwise, it is "<code>none</code>".</p>
-    <p>A <a href="#dfn-service-worker">service worker</a> has an associated <dfn id="dfn-script-resource-map">script resource map</dfn> which is a <a>List</a> of the <a>Record</a> {\[[key]], \[[value]]} where \[[key]] is a <a for="url">URL</a> and \[[value]] is a script resource.</p>
+    <p>A <a href="#dfn-service-worker">service worker</a> has an associated <dfn id="dfn-script-resource-map">script resource map</dfn> which is a <a>List</a> of the <a>Record</a> {\[[key]], \[[value]]} where \[[key]] is a <a for="url">URL</a> and \[[value]] is a <a for="response">response</a>.</p>
     <p>A <a href="#dfn-service-worker">service worker</a> has an associated <dfn id="dfn-skip-waiting-flag">skip waiting flag</dfn>. Unless stated otherwise it is unset.</p>
     <p>A <a href="#dfn-service-worker">service worker</a> has an associated <dfn id="dfn-imported-scripts-updated-flag">imported scripts updated flag</dfn>. It is initially unset.</p>
     <p>A <a href="#dfn-service-worker">service worker</a> has an associated <dfn id="dfn-set-of-event-types-to-handle">set of event types to handle</dfn> whose element type is an <a>event listener</a>'s event type. It is initially set to null.</p>
@@ -2781,42 +2776,28 @@ spec: webidl; urlPrefix: https://heycam.github.io/webidl/
     <section>
       <h4 id="importscripts">{{WorkerGlobalScope/importScripts(urls)}}</h4>
 
-      <p>When the <dfn method for="ServiceWorkerGlobalScope" id="importscripts-method"><code>importScripts(<var>urls</var>)</code></dfn> method is called on a {{ServiceWorkerGlobalScope}} object, the user agent <em class="rfc2119" title="MUST">must</em> <a>import scripts into worker global scope</a>, with the following options:</p>
-
-      <p>To <a>validate the state</a>, the user agent <em class="rfc2119" title="MUST">must</em> do nothing.</p>
-
-      <p>To <a>get a fetch result</a>, the user agent <em class="rfc2119" title="MUST">must</em> run the following steps:</p>
+      <p>When the <dfn method for="ServiceWorkerGlobalScope" id="importscripts-method"><code>importScripts(<var>urls</var>)</code></dfn> method is called on a {{ServiceWorkerGlobalScope}} object, the user agent <em class="rfc2119" title="MUST">must</em> <a>import scripts into worker global scope</a>, given this {{ServiceWorkerGlobalScope}} object and <var>urls</var>, and with the following steps to <a for="fetching scripts">perform the fetch</a> given the <a for="fetch">request</a> <var>request</var>:</p>
 
       <ol>
-        <li>Let <var>serviceWorker</var> be the <var>settings object</var>'s <a>global object</a>'s <a href="#dfn-service-worker-global-scope-service-worker">service worker</a>.</li>
+        <li>Let <var>serviceWorker</var> be <var>request</var>'s <a for="request">client</a>'s <a>global object</a>'s <a href="#dfn-service-worker-global-scope-service-worker">service worker</a>.</li>
         <li>If <var>serviceWorker</var>'s <a href="#dfn-imported-scripts-updated-flag">imported scripts updated flag</a> is unset, then:
           <ol>
-            <li>Attempt to <a>fetch</a> each resource identified by the resulting <a>absolute URLs</a>, from the <a for="resource">origin</a> specified by <em>settings object</em>, using the <a>referrer source</a> specified by <em>settings object</em>, and with the <em>blocking flag</em> set.</li>
+            <li>Let <var>response</var> be the result of <a lt="fetch">fetching</a> <var>request</var>.</li>
+            <li>If <var>response</var>'s <a>unsafe response</a>'s <a for="response">type</a> is not "<code>error</code>", and <var>response</var>'s <a for="response">status</a> is an <a>ok status</a>, then:
+              <ol>
+                <li>If there exists a corresponding Record <var>record</var> for <var>request</var>'s <a for="request">url</a> in <var>serviceWorker</var>'s <a href="#dfn-script-resource-map">script resource map</a>, set <var>record</var>.\[[value]] to <var>response</var>.</li>
+                <li>Else, set a newly-created Record {\[[key]]: <var>url</var>, \[[value]]: <var>response</var>} to <var>serviceWorker</var>'s <a href="#dfn-script-resource-map">script resource map</a>.</li>
+              </ol>
+            </li>
+            <li>Return <var>response</var>.
           </ol>
         </li>
         <li>Else:
           <ol>
-            <li>If there exists a corresponding Record <var>record</var> for <var>url</var> in <var>serviceWorker</var>'s <a href="#dfn-script-resource-map">script resource map</a>, set the script resource to <var>record</var>.\[[value]].</li>
-            <li>Else, set the script resource to null.</li>
+            <li>If there exists a corresponding Record <var>record</var> for <var>url</var> in <var>serviceWorker</var>'s <a href="#dfn-script-resource-map">script resource map</a>, return <var>record</var>.\[[value]].</li>
+            <li>Else, return a <a>network error</a>.</li>
           </ol>
         </li>
-      </ol>
-
-      <p>To <a>postprocess the fetch result</a>, the user agent <em class="rfc2119" title="MUST">must</em> run the following steps:</p>
-
-      <ol>
-        <li>If <var>serviceWorker</var>'s <a href="#dfn-imported-scripts-updated-flag">imported scripts updated flag</a> is unset, then:
-          <ol>
-            <li>If the fetching attempt failed (e.g. the server returned a 4xx or 5xx status code <a lt="http equivalent codes">or equivalent</a>, or there was a DNS error), <a>throw</a> a "{{NetworkError}}" exception and abort all these steps.</li>
-            <li>Else:
-              <ol>
-                <li>If there exists a corresponding Record <var>record</var> for the resulting <a>absolute URL</a> <var>url</var> in <var>serviceWorker</var>'s <a href="#dfn-script-resource-map">script resource map</a>, set <var>record</var>.\[[value]] to the fetched script resource.</li>
-                <li>Else, set a newly-created Record {\[[key]]: <var>url</var>, \[[value]]: the fetched script resource} to <var>serviceWorker</var>'s <a href="#dfn-script-resource-map">script resource map</a>.</li>
-              </ol>
-            </li>
-          </ol>
-        </li>
-        <li>Else, if the script resource is null, <a>throw</a> a "{{NetworkError}}" exception and abort all these steps.</li>
       </ol>
     </section>
   </section>
@@ -3195,9 +3176,9 @@ spec: webidl; urlPrefix: https://heycam.github.io/webidl/
         <dt><em>"<code>classic</code>"</em></dt>
         <dd><p><a>Fetch a classic worker script</a> given <var>job</var>’s <a>serialized</a> <a href="#dfn-job-script-url">script url</a>, <var>job</var>’s <a href="#dfn-job-client">client</a>, and "<code>serviceworker</code>".</p></dd>
         <dt><em>"<code>module</code>"</em></dt>
-        <dd><p><a>Fetch a module script tree</a> given <var>job</var>’s <a>serialized</a> <a href="#dfn-job-script-url">script url</a>, "<code>omit</code>", "<code>serviceworker</code>", and <var>job</var>’s <a href="#dfn-job-client">client</a>.</p></dd>
+        <dd><p><a>Fetch a module worker script tree</a> given <var>job</var>’s <a>serialized</a> <a href="#dfn-job-script-url">script url</a>, <var>job</var>’s <a href="#dfn-job-client">client</a>, "<code>serviceworker</code>", "<code>omit</code>", and the to-be-created <a>environment settings object</a> for this service worker.</p></dd> <!-- TODO: reorganize algorithm so that the worker environment is created before fetching happens -->
         </dl>
-        <p>To <a>set up the request</a> given <var>request</var>, run the following steps:</p>
+        <p>To <a for="fetching scripts">perform the fetch</a> given <var>request</var>, run the following steps if the <a for="fetching scripts">is top-level</a> flag is set:</p>
         <ol>
           <li>Append `<code>Service-Worker</code>`/`<code>script</code>` to <var>request</var>'s <a for="request">header list</a>.
             <p class="note">See the definition of the Service-Worker header in Appendix B: Extended HTTP headers.</p>
@@ -3209,15 +3190,11 @@ spec: webidl; urlPrefix: https://heycam.github.io/webidl/
             </ol>
             <p class="note">Even if the cache mode is not set to "reload", the user agent obeys Cache-Control header's max-age value in the network layer to determine if it should bypass the browser cache.</p>
           </li>
-        </ol>
-        <p>To <a>process the response</a> given <var>response</var>, run the following steps:</p>
-        <ol>
+          <li><a>Fetch</a> <var>request</var>, and asynchronously wait to run the remaining steps as part of fetch's <a>process response</a> for the <a for="fetch">response</a> <var>response</var>.</li>
           <li><a>Extract a MIME type</a> from the <var>response</var>'s <a for="response">header list</a>. If this MIME type (ignoring parameters) is not one of <code>text/javascript</code>, <code>application/x-javascript</code>, and <code>application/javascript</code>, then:
             <ol>
               <li>Invoke <a href="#reject-job-promise-algorithm">Reject Job Promise</a> with <var>job</var> and a "{{SecurityError}}" exception.</li>
-              <li>If <var>newestWorker</var> is null, invoke <a href="#clear-registration-algorithm">Clear Registration</a> algorithm passing <var>registration</var> as its argument.</li>
-              <li>Invoke <a href="#finish-job-algorithm">Finish Job</a> with <var>job</var>.</li>
-              <li>Return false and abort these steps.</li>
+              <li>Asynchronously complete these steps with a <a>network error</a>.</li>
             </ol>
           </li>
           <li>Let <var>serviceWorkerAllowed</var> be the result of <a for="header">parsing</a> `<code>Service-Worker-Allowed</code>` in <var>response</var>'s <a for="response">header list</a>.
@@ -3225,10 +3202,7 @@ spec: webidl; urlPrefix: https://heycam.github.io/webidl/
           </li>
           <li>If <var>serviceWorkerAllowed</var> is failure, then:
             <ol>
-              <li>Invoke <a href="#reject-job-promise-algorithm">Reject Job Promise</a> with <var>job</var> and a <code>TypeError</code>.</li>
-              <li>If <var>newestWorker</var> is null, invoke <a href="#clear-registration-algorithm">Clear Registration</a> algorithm passing <var>registration</var> as its argument.</li>
-              <li>Invoke <a href="#finish-job-algorithm">Finish Job</a> with <var>job</var>.</li>
-              <li>Return false and abort these steps.</li>
+              <li>Asynchronously complete these steps with a <a>network error</a>.</li>
             </ol>
           </li>
           <li>Let <var>scopeURL</var> be <var>registration</var>'s <a href="#dfn-scope-url">scope url</a>.</li>
@@ -3249,9 +3223,7 @@ spec: webidl; urlPrefix: https://heycam.github.io/webidl/
           <li>Else:
             <ol>
               <li>Invoke <a href="#reject-job-promise-algorithm">Reject Job Promise</a> with <var>job</var> and a "{{SecurityError}}" exception.</li>
-              <li>If <var>newestWorker</var> is null, invoke <a href="#clear-registration-algorithm">Clear Registration</a> algorithm passing <var>registration</var> as its argument.</li>
-              <li>Invoke <a href="#finish-job-algorithm">Finish Job</a> with <var>job</var>.</li>
-              <li>Return false and abort these steps.</li>
+              <li>Asynchronously complete these steps with a <a>network error</a>.</li>
             </ol>
           </li>
           <li>If <var>response</var>'s <a for="response">cache state</a> is not "<code>local</code>", set <var>registration</var>'s <a href="#dfn-last-update-check-time">last update check time</a> to the current time.</li>
@@ -3259,7 +3231,11 @@ spec: webidl; urlPrefix: https://heycam.github.io/webidl/
         </ol>
         <p>If the algorithm asynchronously completes with null, then:
           <ol>
-            <li>Invoke <a href="#reject-job-promise-algorithm">Reject Job Promise</a> with <var>job</var> and a <code>TypeError</code>.</li>
+            <li>
+                <p>Invoke <a href="#reject-job-promise-algorithm">Reject Job Promise</a> with <var>job</var> and a <code>TypeError</code>.</p>
+
+                <p class="note">This will do nothing if <a href="#reject-job-promise-algorithm">Reject Job Promise</a> was previously invoked with a "{{SecurityError}}" exception.</p>
+            </li>
             <li>If <var>newestWorker</var> is null, invoke <a href="#clear-registration-algorithm">Clear Registration</a> algorithm passing <var>registration</var> as its argument.</li>
             <li>Invoke <a href="#finish-job-algorithm">Finish Job</a> with <var>job</var> and abort these steps.</li>
           </ol>
@@ -3495,11 +3471,11 @@ spec: webidl; urlPrefix: https://heycam.github.io/webidl/
           <dd>Return UTF-8.</dd>
           <dt>The <a>API base URL</a></dt>
           <dd>Return <var>serviceWorker</var>'s <a href="#dfn-script-url">script url</a>.</dd>
-          <dt>The <a for="resource">origin</a> and <a>effective script origin</a></dt>
+          <dt>The <a for="resource">origin</a></dt>
           <dd>Return its registering <a href="#dfn-service-worker-client">service worker client</a>'s <a for="resource">origin</a>.</dd>
           <dt>The <a>creation URL</a></dt>
           <dd>Return <var>workerGlobalScope</var>'s <a for="workerglobalscope">url</a>.</dd>
-          <dt>The <a>HTTPS state</a></dt>
+          <dt>The <a for="environment settings object">HTTPS state</a></dt>
           <dd>Return <var>workerGlobalScope</var>'s <a for="workerglobalscope">HTTPS state</a>.</dd>
         </dl>
       </li>

--- a/spec/service_worker/index.html
+++ b/spec/service_worker/index.html
@@ -1399,7 +1399,7 @@ pre.idl.highlight { color: #708090; }
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="http://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Service Workers Nightly</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-06-23">23 June 2016</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2016-07-01">1 July 2016</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1736,7 +1736,7 @@ pre.idl.highlight { color: #708090; }
      <p>A <a href="#dfn-service-worker" id="ref-for-dfn-service-worker-20">service worker</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker" data-dfn-type="dfn" data-noexport="" id="dfn-service-worker-id">id</dfn> (an opaque string), which uniquely identifies itself during the lifetime of its <a href="#dfn-containing-service-worker-registration" id="ref-for-dfn-containing-service-worker-registration-1">containing service worker registration</a>.</p>
      <p>A <a href="#dfn-service-worker" id="ref-for-dfn-service-worker-21">service worker</a> is dispatched a set of <dfn class="dfn-paneled" data-dfn-for="service worker" data-dfn-type="dfn" data-noexport="" id="dfn-lifecycle-events">lifecycle events</dfn>, <a href="#service-worker-global-scope-install-event" id="ref-for-service-worker-global-scope-install-event-1">install</a> and <a href="#service-worker-global-scope-activate-event" id="ref-for-service-worker-global-scope-activate-event-1">activate</a>, and <dfn class="dfn-paneled" data-dfn-for="service worker" data-dfn-type="dfn" data-noexport="" id="dfn-functional-events">functional events</dfn> including <a href="#service-worker-global-scope-fetch-event" id="ref-for-service-worker-global-scope-fetch-event-1">fetch</a>.</p>
      <p>A <a href="#dfn-service-worker" id="ref-for-dfn-service-worker-22">service worker</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker" data-dfn-type="dfn" data-noexport="" id="dfn-script-resource">script resource</dfn> (a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-script">script</a>), which represents its own script resource. It is initially set to null. A <a href="#dfn-script-resource" id="ref-for-dfn-script-resource-1">script resource</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker" data-dfn-type="dfn" data-noexport="" id="dfn-has-ever-been-evaluated-flag">has ever been evaluated flag</dfn>. It is initially unset. A <a href="#dfn-script-resource" id="ref-for-dfn-script-resource-2">script resource</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker" data-dfn-type="dfn" data-noexport="" id="dfn-https-state">HTTPS state</dfn> which is "<code>none</code>", "<code>deprecated</code>", or "<code>modern</code>". Unless stated otherwise, it is "<code>none</code>".</p>
-     <p>A <a href="#dfn-service-worker" id="ref-for-dfn-service-worker-23">service worker</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker" data-dfn-type="dfn" data-noexport="" id="dfn-script-resource-map">script resource map</dfn> which is a <a data-link-type="dfn" href="http://www.ecma-international.org/ecma-262/6.0/#sec-list-and-record-specification-type">List</a> of the <a data-link-type="dfn" href="http://www.ecma-international.org/ecma-262/6.0/#sec-list-and-record-specification-type">Record</a> {[[key]], [[value]]} where [[key]] is a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url">URL</a> and [[value]] is a script resource.</p>
+     <p>A <a href="#dfn-service-worker" id="ref-for-dfn-service-worker-23">service worker</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker" data-dfn-type="dfn" data-noexport="" id="dfn-script-resource-map">script resource map</dfn> which is a <a data-link-type="dfn" href="http://www.ecma-international.org/ecma-262/6.0/#sec-list-and-record-specification-type">List</a> of the <a data-link-type="dfn" href="http://www.ecma-international.org/ecma-262/6.0/#sec-list-and-record-specification-type">Record</a> {[[key]], [[value]]} where [[key]] is a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url">URL</a> and [[value]] is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-response">response</a>.</p>
      <p>A <a href="#dfn-service-worker" id="ref-for-dfn-service-worker-24">service worker</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker" data-dfn-type="dfn" data-noexport="" id="dfn-skip-waiting-flag">skip waiting flag</dfn>. Unless stated otherwise it is unset.</p>
      <p>A <a href="#dfn-service-worker" id="ref-for-dfn-service-worker-25">service worker</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker" data-dfn-type="dfn" data-noexport="" id="dfn-imported-scripts-updated-flag">imported scripts updated flag</dfn>. It is initially unset.</p>
      <p>A <a href="#dfn-service-worker" id="ref-for-dfn-service-worker-26">service worker</a> has an associated <dfn class="dfn-paneled" data-dfn-for="service worker" data-dfn-type="dfn" data-noexport="" id="dfn-set-of-event-types-to-handle">set of event types to handle</dfn> whose element type is an <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-event-listener">event listener</a>’s event type. It is initially set to null.</p>
@@ -1813,7 +1813,7 @@ pre.idl.highlight { color: #708090; }
     <h2 class="heading settled" data-level="3" id="document-context"><span class="secno">3. </span><span class="content">Client Context</span><a class="self-link" href="#document-context"></a></h2>
     <div class="example" id="example-dd1d6d2d">
      <a class="self-link" href="#example-dd1d6d2d"></a> Bootstrapping with a ServiceWorker: 
-<pre class="lang-js highlight"><span class="c1">// scope defaults to the path the script sits in</span>
+<pre class="lang-js highlight"><span></span><span class="c1">// scope defaults to the path the script sits in</span>
 <span class="c1">// "/" in this example</span>
 <span class="nx">navigator</span><span class="p">.</span><span class="nx">serviceWorker</span><span class="p">.</span><span class="nx">register</span><span class="p">(</span><span class="s2">"/serviceworker.js"</span><span class="p">).</span><span class="nx">then</span><span class="p">(</span>
   <span class="kd">function</span><span class="p">(</span><span class="nx">registration</span><span class="p">)</span> <span class="p">{</span>
@@ -1856,7 +1856,7 @@ pre.idl.highlight { color: #708090; }
       <div class="example" id="example-0c9aabd5">
        <a class="self-link" href="#example-0c9aabd5"></a> 
        <p>For example, consider a document created by a navigation to <code>https://example.com/app.html</code> which <a href="#on-fetch-request-algorithm">matches</a> via the following registration call which has been previously executed:</p>
-<pre class="lang-js highlight"><span class="c1">// Script on the page https://example.com/app.html</span>
+<pre class="lang-js highlight"><span></span><span class="c1">// Script on the page https://example.com/app.html</span>
 <span class="nx">navigator</span><span class="p">.</span><span class="nx">serviceWorker</span><span class="p">.</span><span class="nx">register</span><span class="p">(</span><span class="s2">"/service_worker.js"</span><span class="p">,</span> <span class="p">{</span> <span class="nx">scope</span><span class="o">:</span> <span class="s2">"/"</span> <span class="p">});</span>
 </pre>
        <p>The value of <code>navigator.serviceWorker.controller.scriptURL</code> will be "<code>https://example.com/service_worker.js</code>".</p>
@@ -2245,7 +2245,7 @@ pre.idl.highlight { color: #708090; }
     <h2 class="heading settled" data-level="4" id="execution-context"><span class="secno">4. </span><span class="content">Execution Context</span><a class="self-link" href="#execution-context"></a></h2>
     <div class="example" id="example-7fd0ecd9">
      <a class="self-link" href="#example-7fd0ecd9"></a> Serving Cached Resources: 
-<pre class="lang-js highlight"><span class="c1">// caching.js</span>
+<pre class="lang-js highlight"><span></span><span class="c1">// caching.js</span>
 <span class="k">this</span><span class="p">.</span><span class="nx">addEventListener</span><span class="p">(</span><span class="s2">"install"</span><span class="p">,</span> <span class="kd">function</span><span class="p">(</span><span class="nx">e</span><span class="p">)</span> <span class="p">{</span>
   <span class="nx">e</span><span class="p">.</span><span class="nx">waitUntil</span><span class="p">(</span>
     <span class="c1">// Open a cache of resources.</span>
@@ -3171,10 +3171,10 @@ pre.idl.highlight { color: #708090; }
 <pre class="highlight">Link: &lt;/js/sw.js>; rel="serviceworker"; scope="/"
 </pre>
       <p>has more or less the same effect as a document being loaded in a secure context with the following <code>link</code> element:</p>
-<pre class="lang-html highlight"><span class="nt">&lt;link</span> <span class="na">rel=</span><span class="s">"serviceworker"</span> <span class="na">href=</span><span class="s">"/js/sw.js"</span> <span class="na">scope=</span><span class="s">"/"</span><span class="nt">></span>
+<pre class="lang-html highlight"><span></span><span class="p">&lt;</span><span class="nt">link</span> <span class="na">rel</span><span class="o">=</span><span class="s">"serviceworker"</span> <span class="na">href</span><span class="o">=</span><span class="s">"/js/sw.js"</span> <span class="na">scope</span><span class="o">=</span><span class="s">"/"</span><span class="p">></span>
 </pre>
       <p>which is more or less equivalent to the page containing javascript code like:</p>
-<pre class="lang-js highlight"><span class="nx">navigator</span><span class="p">.</span><span class="nx">serviceworker</span><span class="p">.</span><span class="nx">register</span><span class="p">(</span><span class="s2">"/js/sw.js"</span><span class="p">,</span> <span class="p">{</span> <span class="nx">scope</span><span class="o">:</span> <span class="s2">"/"</span> <span class="p">});</span>
+<pre class="lang-js highlight"><span></span><span class="nx">navigator</span><span class="p">.</span><span class="nx">serviceworker</span><span class="p">.</span><span class="nx">register</span><span class="p">(</span><span class="s2">"/js/sw.js"</span><span class="p">,</span> <span class="p">{</span> <span class="nx">scope</span><span class="o">:</span> <span class="s2">"/"</span> <span class="p">});</span>
 </pre>
      </div>
     </section>
@@ -3791,37 +3791,27 @@ pre.idl.highlight { color: #708090; }
      </section>
      <section>
       <h4 class="heading settled" data-level="7.3.2" id="importscripts"><span class="secno">7.3.2. </span><span class="content"><code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#dom-workerglobalscope-importscripts">importScripts(urls)</a></code></span><a class="self-link" href="#importscripts"></a></h4>
-      <p>When the <dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="method" data-export="" id="importscripts-method"><code>importScripts(<var>urls</var>)</code></dfn> method is called on a <code class="idl"><a data-link-type="idl" href="#service-worker-global-scope-interface" id="ref-for-service-worker-global-scope-interface-12">ServiceWorkerGlobalScope</a></code> object, the user agent <em class="rfc2119" title="MUST">must</em> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#import-scripts-into-worker-global-scope">import scripts into worker global scope</a>, with the following options:</p>
-      <p>To <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#validate-the-state">validate the state</a>, the user agent <em class="rfc2119" title="MUST">must</em> do nothing.</p>
-      <p>To <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#get-a-fetch-result">get a fetch result</a>, the user agent <em class="rfc2119" title="MUST">must</em> run the following steps:</p>
+      <p>When the <dfn class="dfn-paneled idl-code" data-dfn-for="ServiceWorkerGlobalScope" data-dfn-type="method" data-export="" id="importscripts-method"><code>importScripts(<var>urls</var>)</code></dfn> method is called on a <code class="idl"><a data-link-type="idl" href="#service-worker-global-scope-interface" id="ref-for-service-worker-global-scope-interface-12">ServiceWorkerGlobalScope</a></code> object, the user agent <em class="rfc2119" title="MUST">must</em> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#import-scripts-into-worker-global-scope">import scripts into worker global scope</a>, given this <code class="idl"><a data-link-type="idl" href="#service-worker-global-scope-interface" id="ref-for-service-worker-global-scope-interface-13">ServiceWorkerGlobalScope</a></code> object and <var>urls</var>, and with the following steps to <a data-link-type="dfn">perform the fetch</a> given the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request">request</a> <var>request</var>:</p>
       <ol>
-       <li>Let <var>serviceWorker</var> be the <var>settings object</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object">global object</a>’s <a href="#dfn-service-worker-global-scope-service-worker" id="ref-for-dfn-service-worker-global-scope-service-worker-21">service worker</a>.
+       <li>Let <var>serviceWorker</var> be <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client">client</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object">global object</a>’s <a href="#dfn-service-worker-global-scope-service-worker" id="ref-for-dfn-service-worker-global-scope-service-worker-21">service worker</a>.
        <li>
         If <var>serviceWorker</var>’s <a href="#dfn-imported-scripts-updated-flag" id="ref-for-dfn-imported-scripts-updated-flag-1">imported scripts updated flag</a> is unset, then: 
         <ol>
-         <li>Attempt to <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">fetch</a> each resource identified by the resulting <a data-link-type="dfn" href="https://url.spec.whatwg.org/#syntax-url-absolute">absolute URLs</a>, from the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#origin-2">origin</a> specified by <em>settings object</em>, using the <a data-link-type="dfn">referrer source</a> specified by <em>settings object</em>, and with the <em>blocking flag</em> set.
+         <li>Let <var>response</var> be the result of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">fetching</a> <var>request</var>.
+         <li>
+          If <var>response</var>’s <a data-link-type="dfn">unsafe response</a>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-type">type</a> is not "<code>error</code>", and <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-status">status</a> is an <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#ok-status">ok status</a>, then: 
+          <ol>
+           <li>If there exists a corresponding Record <var>record</var> for <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-url">url</a> in <var>serviceWorker</var>’s <a href="#dfn-script-resource-map" id="ref-for-dfn-script-resource-map-1">script resource map</a>, set <var>record</var>.[[value]] to <var>response</var>.
+           <li>Else, set a newly-created Record {[[key]]: <var>url</var>, [[value]]: <var>response</var>} to <var>serviceWorker</var>’s <a href="#dfn-script-resource-map" id="ref-for-dfn-script-resource-map-2">script resource map</a>.
+          </ol>
+         <li>Return <var>response</var>. 
         </ol>
        <li>
         Else: 
         <ol>
-         <li>If there exists a corresponding Record <var>record</var> for <var>url</var> in <var>serviceWorker</var>’s <a href="#dfn-script-resource-map" id="ref-for-dfn-script-resource-map-1">script resource map</a>, set the script resource to <var>record</var>.[[value]].
-         <li>Else, set the script resource to null.
+         <li>If there exists a corresponding Record <var>record</var> for <var>url</var> in <var>serviceWorker</var>’s <a href="#dfn-script-resource-map" id="ref-for-dfn-script-resource-map-3">script resource map</a>, return <var>record</var>.[[value]].
+         <li>Else, return a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error">network error</a>.
         </ol>
-      </ol>
-      <p>To <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#postprocess-the-fetch-result">postprocess the fetch result</a>, the user agent <em class="rfc2119" title="MUST">must</em> run the following steps:</p>
-      <ol>
-       <li>
-        If <var>serviceWorker</var>’s <a href="#dfn-imported-scripts-updated-flag" id="ref-for-dfn-imported-scripts-updated-flag-2">imported scripts updated flag</a> is unset, then: 
-        <ol>
-         <li>If the fetching attempt failed (e.g. the server returned a 4xx or 5xx status code <a data-link-type="dfn">or equivalent</a>, or there was a DNS error), <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#networkerror">NetworkError</a></code>" exception and abort all these steps.
-         <li>
-          Else: 
-          <ol>
-           <li>If there exists a corresponding Record <var>record</var> for the resulting <a data-link-type="dfn" href="https://url.spec.whatwg.org/#syntax-url-absolute">absolute URL</a> <var>url</var> in <var>serviceWorker</var>’s <a href="#dfn-script-resource-map" id="ref-for-dfn-script-resource-map-2">script resource map</a>, set <var>record</var>.[[value]] to the fetched script resource.
-           <li>Else, set a newly-created Record {[[key]]: <var>url</var>, [[value]]: the fetched script resource} to <var>serviceWorker</var>’s <a href="#dfn-script-resource-map" id="ref-for-dfn-script-resource-map-3">script resource map</a>.
-          </ol>
-        </ol>
-       <li>Else, if the script resource is null, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw">throw</a> a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#networkerror">NetworkError</a></code>" exception and abort all these steps.
       </ol>
      </section>
     </section>
@@ -3875,7 +3865,7 @@ interface FunctionalEvent : ExtendableEvent {
      </section>
      <section>
       <h3 class="heading settled" data-level="9.3" id="extension-to-service-worker-global-scope"><span class="secno">9.3. </span><span class="content">Define Event Handler</span><a class="self-link" href="#extension-to-service-worker-global-scope"></a></h3>
-      <p>Specifications <em class="rfc2119" title="MAY">may</em> define an event handler attribute for the corresponding <a href="#dfn-functional-events" id="ref-for-dfn-functional-events-8">functional event</a> using <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-partial-interface">partial interface</a> definition to the <code class="idl"><a data-link-type="idl" href="#service-worker-global-scope-interface" id="ref-for-service-worker-global-scope-interface-13">ServiceWorkerGlobalScope</a></code> interface:</p>
+      <p>Specifications <em class="rfc2119" title="MAY">may</em> define an event handler attribute for the corresponding <a href="#dfn-functional-events" id="ref-for-dfn-functional-events-8">functional event</a> using <a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-partial-interface">partial interface</a> definition to the <code class="idl"><a data-link-type="idl" href="#service-worker-global-scope-interface" id="ref-for-service-worker-global-scope-interface-14">ServiceWorkerGlobalScope</a></code> interface:</p>
 <pre class="example idl def" data-no-idl="" id="example-8148d1c6"><a class="self-link" href="#example-8148d1c6"></a>partial interface ServiceWorkerGlobalScope {
   attribute EventHandler on<em>functionalevent</em>;
 };
@@ -3884,7 +3874,7 @@ interface FunctionalEvent : ExtendableEvent {
      <section>
       <h3 class="heading settled" data-level="9.4" id="request-functional-event-dispatch"><span class="secno">9.4. </span><span class="content">Request Functional Event Dispatch</span><a class="self-link" href="#request-functional-event-dispatch"></a></h3>
       <p>To request a <a href="#dfn-functional-events" id="ref-for-dfn-functional-events-9">functional event</a> dispatch to a <a href="#dfn-service-worker" id="ref-for-dfn-service-worker-100">service worker</a>, specifications <em class="rfc2119" title="MAY">may</em> invoke <a href="#handle-functional-event-algorithm">Handle Functional Event</a> algorithm, or its <a href="#dfn-processing-equivalence" id="ref-for-dfn-processing-equivalence-47">equivalent</a>, with its <a href="#dfn-service-worker-registration" id="ref-for-dfn-service-worker-registration-48">service worker registration</a> <var>registration</var> and the algorithm <var>callbackSteps</var> as the arguments.</p>
-      <p>Specifications <em class="rfc2119" title="MAY">may</em> define an algorithm <var>callbackSteps</var> where the corresponding <a href="#dfn-functional-events" id="ref-for-dfn-functional-events-10">functional event</a> can be created and fired with specification specific objects. The algorithm is passed <var>globalObject</var> (a <code class="idl"><a data-link-type="idl" href="#service-worker-global-scope-interface" id="ref-for-service-worker-global-scope-interface-14">ServiceWorkerGlobalScope</a></code> object) at which it <em class="rfc2119" title="MAY">may</em> fire its <a href="#dfn-functional-events" id="ref-for-dfn-functional-events-11">functional events</a>. This algorithm is called on a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">task</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queued</a> by <a href="#handle-functional-event-algorithm">Handle Functional Event</a> algorithm.</p>
+      <p>Specifications <em class="rfc2119" title="MAY">may</em> define an algorithm <var>callbackSteps</var> where the corresponding <a href="#dfn-functional-events" id="ref-for-dfn-functional-events-10">functional event</a> can be created and fired with specification specific objects. The algorithm is passed <var>globalObject</var> (a <code class="idl"><a data-link-type="idl" href="#service-worker-global-scope-interface" id="ref-for-service-worker-global-scope-interface-15">ServiceWorkerGlobalScope</a></code> object) at which it <em class="rfc2119" title="MAY">may</em> fire its <a href="#dfn-functional-events" id="ref-for-dfn-functional-events-11">functional events</a>. This algorithm is called on a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">task</a> <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queued</a> by <a href="#handle-functional-event-algorithm">Handle Functional Event</a> algorithm.</p>
       <p class="note" role="note">See an <a href="https://notifications.spec.whatwg.org/#activating-a-notification">example</a> hook defined in <a data-link-type="biblio" href="#biblio-notifications">Notifications API</a>.</p>
      </section>
     </section>
@@ -4138,12 +4128,12 @@ interface FunctionalEvent : ExtendableEvent {
         <dl>
          <dt><em>"<code>classic</code>"</em>
          <dd>
-          <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-classic-worker-script">Fetch a classic worker script</a> given <var>job</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer">serialized</a> <a href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-7">script url</a>, <var>job</var>’s <a href="#dfn-job-client" id="ref-for-dfn-job-client-10">client</a>, and "<code>serviceworker</code>".</p>
+          <p><a data-link-type="dfn">Fetch a classic worker script</a> given <var>job</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer">serialized</a> <a href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-7">script url</a>, <var>job</var>’s <a href="#dfn-job-client" id="ref-for-dfn-job-client-10">client</a>, and "<code>serviceworker</code>".</p>
          <dt><em>"<code>module</code>"</em>
          <dd>
-          <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-module-script-tree">Fetch a module script tree</a> given <var>job</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer">serialized</a> <a href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-8">script url</a>, "<code>omit</code>", "<code>serviceworker</code>", and <var>job</var>’s <a href="#dfn-job-client" id="ref-for-dfn-job-client-11">client</a>.</p>
+          <p><a data-link-type="dfn">Fetch a module worker script tree</a> given <var>job</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-serializer">serialized</a> <a href="#dfn-job-script-url" id="ref-for-dfn-job-script-url-8">script url</a>, <var>job</var>’s <a href="#dfn-job-client" id="ref-for-dfn-job-client-11">client</a>, "<code>serviceworker</code>", "<code>omit</code>", and the to-be-created <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a> for this service worker.</p>
         </dl>
-        <p>To <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#fetching-scripts-set-up-request">set up the request</a> given <var>request</var>, run the following steps:</p>
+        <p>To <a data-link-type="dfn">perform the fetch</a> given <var>request</var>, run the following steps if the <a data-link-type="dfn">is top-level</a> flag is set:</p>
         <ol>
          <li>
           Append `<code>Service-Worker</code>`/`<code>script</code>` to <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-header-list">header list</a>. 
@@ -4155,16 +4145,12 @@ interface FunctionalEvent : ExtendableEvent {
            <li>If the time difference in seconds calculated by the current time minus <var>registration</var>’s <a href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time-2">last update check time</a> is greater than 86400, or <em>force bypass cache flag</em> is set, set <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-cache-mode">cache mode</a> to "<code>reload</code>".
           </ol>
           <p class="note" role="note">Even if the cache mode is not set to "reload", the user agent obeys Cache-Control header’s max-age value in the network layer to determine if it should bypass the browser cache.</p>
-        </ol>
-        <p>To <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#fetching-scripts-process-response">process the response</a> given <var>response</var>, run the following steps:</p>
-        <ol>
+         <li><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-fetch">Fetch</a> <var>request</var>, and asynchronously wait to run the remaining steps as part of fetch’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#process-response">process response</a> for the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response">response</a> <var>response</var>.
          <li>
           <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header-extract-mime-type">Extract a MIME type</a> from the <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-header-list">header list</a>. If this MIME type (ignoring parameters) is not one of <code>text/javascript</code>, <code>application/x-javascript</code>, and <code>application/javascript</code>, then: 
           <ol>
            <li>Invoke <a href="#reject-job-promise-algorithm">Reject Job Promise</a> with <var>job</var> and a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#securityerror">SecurityError</a></code>" exception.
-           <li>If <var>newestWorker</var> is null, invoke <a href="#clear-registration-algorithm">Clear Registration</a> algorithm passing <var>registration</var> as its argument.
-           <li>Invoke <a href="#finish-job-algorithm">Finish Job</a> with <var>job</var>.
-           <li>Return false and abort these steps.
+           <li>Asynchronously complete these steps with a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error">network error</a>.
           </ol>
          <li>
           Let <var>serviceWorkerAllowed</var> be the result of <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-header-parse">parsing</a> `<code>Service-Worker-Allowed</code>` in <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-header-list">header list</a>. 
@@ -4172,10 +4158,7 @@ interface FunctionalEvent : ExtendableEvent {
          <li>
           If <var>serviceWorkerAllowed</var> is failure, then: 
           <ol>
-           <li>Invoke <a href="#reject-job-promise-algorithm">Reject Job Promise</a> with <var>job</var> and a <code>TypeError</code>.
-           <li>If <var>newestWorker</var> is null, invoke <a href="#clear-registration-algorithm">Clear Registration</a> algorithm passing <var>registration</var> as its argument.
-           <li>Invoke <a href="#finish-job-algorithm">Finish Job</a> with <var>job</var>.
-           <li>Return false and abort these steps.
+           <li>Asynchronously complete these steps with a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error">network error</a>.
           </ol>
          <li>Let <var>scopeURL</var> be <var>registration</var>’s <a href="#dfn-scope-url" id="ref-for-dfn-scope-url-15">scope url</a>.
          <li>Let <var>maxScopeString</var> be null.
@@ -4196,16 +4179,16 @@ interface FunctionalEvent : ExtendableEvent {
           Else: 
           <ol>
            <li>Invoke <a href="#reject-job-promise-algorithm">Reject Job Promise</a> with <var>job</var> and a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#securityerror">SecurityError</a></code>" exception.
-           <li>If <var>newestWorker</var> is null, invoke <a href="#clear-registration-algorithm">Clear Registration</a> algorithm passing <var>registration</var> as its argument.
-           <li>Invoke <a href="#finish-job-algorithm">Finish Job</a> with <var>job</var>.
-           <li>Return false and abort these steps.
+           <li>Asynchronously complete these steps with a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-network-error">network error</a>.
           </ol>
          <li>If <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-cache-state">cache state</a> is not "<code>local</code>", set <var>registration</var>’s <a href="#dfn-last-update-check-time" id="ref-for-dfn-last-update-check-time-3">last update check time</a> to the current time.
          <li>Return true.
         </ol>
         <p>If the algorithm asynchronously completes with null, then: </p>
         <ol>
-         <li>Invoke <a href="#reject-job-promise-algorithm">Reject Job Promise</a> with <var>job</var> and a <code>TypeError</code>.
+         <li>
+          <p>Invoke <a href="#reject-job-promise-algorithm">Reject Job Promise</a> with <var>job</var> and a <code>TypeError</code>.</p>
+          <p class="note" role="note">This will do nothing if <a href="#reject-job-promise-algorithm">Reject Job Promise</a> was previously invoked with a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#securityerror">SecurityError</a></code>" exception.</p>
          <li>If <var>newestWorker</var> is null, invoke <a href="#clear-registration-algorithm">Clear Registration</a> algorithm passing <var>registration</var> as its argument.
          <li>Invoke <a href="#finish-job-algorithm">Finish Job</a> with <var>job</var> and abort these steps.
         </ol>
@@ -4315,7 +4298,7 @@ interface FunctionalEvent : ExtendableEvent {
          <li>If <var>newestWorker</var> is null, invoke <a href="#clear-registration-algorithm">Clear Registration</a> algorithm passing <var>registration</var> as its argument.
          <li>Invoke <a href="#finish-job-algorithm">Finish Job</a> with <var>job</var> and abort these steps.
         </ol>
-       <li>Set <var>registration</var>’s <a href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-11">installing worker</a>’s <a href="#dfn-imported-scripts-updated-flag" id="ref-for-dfn-imported-scripts-updated-flag-3">imported scripts updated flag</a>.
+       <li>Set <var>registration</var>’s <a href="#dfn-installing-worker" id="ref-for-dfn-installing-worker-11">installing worker</a>’s <a href="#dfn-imported-scripts-updated-flag" id="ref-for-dfn-imported-scripts-updated-flag-2">imported scripts updated flag</a>.
        <li>
         If <var>registration</var>’s <a href="#dfn-waiting-worker" id="ref-for-dfn-waiting-worker-6">waiting worker</a> is not null, then: 
         <ol>
@@ -4410,7 +4393,7 @@ interface FunctionalEvent : ExtendableEvent {
        <li>
         Call the JavaScript <a href="https://tc39.github.io/ecma262/#sec-initializehostdefinedrealm">InitializeHostDefinedRealm()</a> abstract operation with the following customizations: 
         <ul>
-         <li>For the global object, create a new <code class="idl"><a data-link-type="idl" href="#service-worker-global-scope-interface" id="ref-for-service-worker-global-scope-interface-15">ServiceWorkerGlobalScope</a></code> object. Let <var>workerGlobalScope</var> be the created object.
+         <li>For the global object, create a new <code class="idl"><a data-link-type="idl" href="#service-worker-global-scope-interface" id="ref-for-service-worker-global-scope-interface-16">ServiceWorkerGlobalScope</a></code> object. Let <var>workerGlobalScope</var> be the created object.
          <li>Let <var>realmExecutionContext</var> be the created <a href="https://tc39.github.io/ecma262/#sec-execution-contexts">JavaScript execution context</a>.
         </ul>
        <li>Let <var>workerEventLoop</var> be a newly created <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loop</a>.
@@ -4431,7 +4414,7 @@ interface FunctionalEvent : ExtendableEvent {
          <dd>Return UTF-8.
          <dt>The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#api-base-url">API base URL</a>
          <dd>Return <var>serviceWorker</var>’s <a href="#dfn-script-url" id="ref-for-dfn-script-url-9">script url</a>.
-         <dt>The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#origin-2">origin</a> and <a data-link-type="dfn">effective script origin</a>
+         <dt>The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#origin-2">origin</a>
          <dd>Return its registering <a href="#dfn-service-worker-client" id="ref-for-dfn-service-worker-client-41">service worker client</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#origin-2">origin</a>.
          <dt>The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#creation-url">creation URL</a>
          <dd>Return <var>workerGlobalScope</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-url">url</a>.
@@ -5248,7 +5231,7 @@ interface FunctionalEvent : ExtendableEvent {
       </dl>
       <div class="example" id="example-c971b856">
        <a class="self-link" href="#example-c971b856"></a> Default scope: 
-<pre class="lang-js highlight"><span class="c1">// Maximum allowed scope defaults to the path the script sits in</span>
+<pre class="lang-js highlight"><span></span><span class="c1">// Maximum allowed scope defaults to the path the script sits in</span>
 <span class="c1">// "/js" in this example</span>
 <span class="nx">navigator</span><span class="p">.</span><span class="nx">serviceWorker</span><span class="p">.</span><span class="nx">register</span><span class="p">(</span><span class="s2">"/js/sw.js"</span><span class="p">).</span><span class="nx">then</span><span class="p">(</span><span class="kd">function</span><span class="p">()</span> <span class="p">{</span>
   <span class="nx">console</span><span class="p">.</span><span class="nx">log</span><span class="p">(</span><span class="s2">"Install succeeded with the default scope '/js'."</span><span class="p">);</span>
@@ -5257,7 +5240,7 @@ interface FunctionalEvent : ExtendableEvent {
       </div>
       <div class="example" id="example-fc88e43e">
        <a class="self-link" href="#example-fc88e43e"></a> Upper path without Service-Worker-Allowed header: 
-<pre class="lang-js highlight"><span class="c1">// Set the scope to an upper path of the script location</span>
+<pre class="lang-js highlight"><span></span><span class="c1">// Set the scope to an upper path of the script location</span>
 <span class="c1">// Response has no Service-Worker-Allowed header</span>
 <span class="nx">navigator</span><span class="p">.</span><span class="nx">serviceWorker</span><span class="p">.</span><span class="nx">register</span><span class="p">(</span><span class="s2">"/js/sw.js"</span><span class="p">,</span> <span class="p">{</span> <span class="nx">scope</span><span class="o">:</span> <span class="s2">"/"</span> <span class="p">}).</span><span class="k">catch</span><span class="p">(</span><span class="kd">function</span><span class="p">()</span> <span class="p">{</span>
   <span class="nx">console</span><span class="p">.</span><span class="nx">error</span><span class="p">(</span><span class="s2">"Install failed due to the path restriction violation."</span><span class="p">);</span>
@@ -5266,7 +5249,7 @@ interface FunctionalEvent : ExtendableEvent {
       </div>
       <div class="example" id="example-a6511e54">
        <a class="self-link" href="#example-a6511e54"></a> Upper path with Service-Worker-Allowed header: 
-<pre class="lang-js highlight"><span class="c1">// Set the scope to an upper path of the script location</span>
+<pre class="lang-js highlight"><span></span><span class="c1">// Set the scope to an upper path of the script location</span>
 <span class="c1">// Response included "Service-Worker-Allowed : /"</span>
 <span class="nx">navigator</span><span class="p">.</span><span class="nx">serviceWorker</span><span class="p">.</span><span class="nx">register</span><span class="p">(</span><span class="s2">"/js/sw.js"</span><span class="p">,</span> <span class="p">{</span> <span class="nx">scope</span><span class="o">:</span> <span class="s2">"/"</span> <span class="p">}).</span><span class="nx">then</span><span class="p">(</span><span class="kd">function</span><span class="p">()</span> <span class="p">{</span>
   <span class="nx">console</span><span class="p">.</span><span class="nx">log</span><span class="p">(</span><span class="s2">"Install succeeded as the max allowed scope was overriden to '/'."</span><span class="p">);</span>
@@ -5275,7 +5258,7 @@ interface FunctionalEvent : ExtendableEvent {
       </div>
       <div class="example" id="example-8e526533">
        <a class="self-link" href="#example-8e526533"></a> A path restriction voliation even with Service-Worker-Allowed header: 
-<pre class="lang-js highlight"><span class="c1">// Set the scope to an upper path of the script location</span>
+<pre class="lang-js highlight"><span></span><span class="c1">// Set the scope to an upper path of the script location</span>
 <span class="c1">// Response included "Service-Worker-Allowed : /foo"</span>
 <span class="nx">navigator</span><span class="p">.</span><span class="nx">serviceWorker</span><span class="p">.</span><span class="nx">register</span><span class="p">(</span><span class="s2">"/foo/bar/sw.js"</span><span class="p">,</span> <span class="p">{</span> <span class="nx">scope</span><span class="o">:</span> <span class="s2">"/"</span> <span class="p">}).</span><span class="k">catch</span><span class="p">(</span><span class="kd">function</span><span class="p">()</span> <span class="p">{</span>
   <span class="nx">console</span><span class="p">.</span><span class="nx">error</span><span class="p">(</span><span class="s2">"Install failed as the scope is still out of the overriden maximum allowed scope."</span><span class="p">);</span>
@@ -5838,7 +5821,7 @@ interface FunctionalEvent : ExtendableEvent {
      <li><a href="https://fetch.spec.whatwg.org/#concept-readablestream">readablestream</a>
      <li><a href="https://fetch.spec.whatwg.org/#concept-request-redirect-mode">redirect mode</a>
      <li><a href="https://fetch.spec.whatwg.org/#concept-request">request</a>
-     <li><a href="https://fetch.spec.whatwg.org/#concept-response">response</a>
+     <li><a href="https://fetch.spec.whatwg.org/#concept-response-response">response</a>
      <li><a href="https://fetch.spec.whatwg.org/#skip-service-worker-flag">skip service worker flag</a>
      <li><a href="https://fetch.spec.whatwg.org/#concept-response-status">status</a>
      <li><a href="https://fetch.spec.whatwg.org/#concept-body-stream">stream</a>
@@ -5886,11 +5869,8 @@ interface FunctionalEvent : ExtendableEvent {
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">event loops</a>
      <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#exceptions-enabled">exceptions enabled flag</a>
      <li><a href="https://html.spec.whatwg.org/multipage/semantics.html#external-resource-link">external resource link</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-classic-worker-script">fetch a classic worker script</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-module-script-tree">fetch a module script tree</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#fire-a-simple-event">fire a simple event</a>
      <li><a href="https://html.spec.whatwg.org/multipage/interaction.html#focusing-steps">focusing steps</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/workers.html#get-a-fetch-result">get a fetch result</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object">global object</a>
      <li><a href="https://html.spec.whatwg.org/multipage/interaction.html#has-focus-steps">has focus steps</a>
      <li><a href="https://html.spec.whatwg.org/multipage/semantics.html#attr-link-href">href</a>
@@ -5908,8 +5888,6 @@ interface FunctionalEvent : ExtendableEvent {
      <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context">nested browsing contexts</a>
      <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#origin-2">origin</a>
      <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#parent-browsing-context">parent browsing context</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/workers.html#postprocess-the-fetch-result">postprocess the fetch result</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#fetching-scripts-process-response">process the response</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a task</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#realm-execution-context">realm execution context</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">relevant settings object</a>
@@ -5923,7 +5901,6 @@ interface FunctionalEvent : ExtendableEvent {
      <li><a href="https://html.spec.whatwg.org/multipage/workers.html#runtime-script-errors-2">runtime script errors handling</a>
      <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">same origin</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-script">script</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#fetching-scripts-set-up-request">set up the request</a>
      <li><a href="https://html.spec.whatwg.org/multipage/workers.html#shared-workers">shared workers</a>
      <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#source-browsing-context">source browsing context</a>
      <li><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#structuredclonewithtransfer">structuredclonewithtransfer</a>
@@ -5941,7 +5918,6 @@ interface FunctionalEvent : ExtendableEvent {
      <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#unload-a-document">unload a document</a>
      <li><a href="https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-url">url</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#user-interaction-task-source">user interaction task source</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/workers.html#validate-the-state">validate the state</a>
      <li><a href="https://html.spec.whatwg.org/multipage/workers.html#workers">web worker</a>
     </ul>
    <li>
@@ -6004,7 +5980,6 @@ interface FunctionalEvent : ExtendableEvent {
     <ul>
      <li><a href="https://heycam.github.io/webidl/#invalidaccesserror">InvalidAccessError</a>
      <li><a href="https://heycam.github.io/webidl/#invalidstateerror">InvalidStateError</a>
-     <li><a href="https://heycam.github.io/webidl/#networkerror">NetworkError</a>
      <li><a href="https://heycam.github.io/webidl/#quotaexceedederror">QuotaExceededError</a>
      <li><a href="https://heycam.github.io/webidl/#securityerror">SecurityError</a>
      <li><a href="https://heycam.github.io/webidl/#dom-USVString">USVString</a>
@@ -6049,7 +6024,7 @@ interface FunctionalEvent : ExtendableEvent {
    <dt id="biblio-whatwg-dom">[WHATWG-DOM]
    <dd>Anne van Kesteren. <a href="https://dom.spec.whatwg.org/">DOM Standard</a>. Living Standard. URL: <a href="https://dom.spec.whatwg.org/">https://dom.spec.whatwg.org/</a>
    <dt id="biblio-whatwg-url">[WHATWG-URL]
-   <dd>Anne van Kesteren; Sam Ruby. <a href="https://url.spec.whatwg.org/">URL Standard</a>. Living Standard. URL: <a href="https://url.spec.whatwg.org/">https://url.spec.whatwg.org/</a>
+   <dd>Anne van Kesteren. <a href="https://url.spec.whatwg.org/">URL Standard</a>. Living Standard. URL: <a href="https://url.spec.whatwg.org/">https://url.spec.whatwg.org/</a>
   </dl>
   <h3 class="no-num no-ref heading settled" id="informative"><span class="content">Informative References</span><a class="self-link" href="#informative"></a></h3>
   <dl>
@@ -6500,8 +6475,8 @@ interface FunctionalEvent : ExtendableEvent {
   <aside class="dfn-panel" data-for="dfn-imported-scripts-updated-flag">
    <b><a href="#dfn-imported-scripts-updated-flag">#dfn-imported-scripts-updated-flag</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dfn-imported-scripts-updated-flag-1">7.3.2. importScripts(urls)</a> <a href="#ref-for-dfn-imported-scripts-updated-flag-2">(2)</a>
-    <li><a href="#ref-for-dfn-imported-scripts-updated-flag-3">Install</a>
+    <li><a href="#ref-for-dfn-imported-scripts-updated-flag-1">7.3.2. importScripts(urls)</a>
+    <li><a href="#ref-for-dfn-imported-scripts-updated-flag-2">Install</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-set-of-event-types-to-handle">
@@ -7144,10 +7119,10 @@ interface FunctionalEvent : ExtendableEvent {
     <li><a href="#ref-for-service-worker-global-scope-interface-9">4.3. Clients</a>
     <li><a href="#ref-for-service-worker-global-scope-interface-10">4.4. ExtendableEvent</a>
     <li><a href="#ref-for-service-worker-global-scope-interface-11">4.9. Events</a>
-    <li><a href="#ref-for-service-worker-global-scope-interface-12">7.3.2. importScripts(urls)</a>
-    <li><a href="#ref-for-service-worker-global-scope-interface-13">9.3. Define Event Handler</a>
-    <li><a href="#ref-for-service-worker-global-scope-interface-14">9.4. Request Functional Event Dispatch</a>
-    <li><a href="#ref-for-service-worker-global-scope-interface-15">Run Service Worker</a>
+    <li><a href="#ref-for-service-worker-global-scope-interface-12">7.3.2. importScripts(urls)</a> <a href="#ref-for-service-worker-global-scope-interface-13">(2)</a>
+    <li><a href="#ref-for-service-worker-global-scope-interface-14">9.3. Define Event Handler</a>
+    <li><a href="#ref-for-service-worker-global-scope-interface-15">9.4. Request Functional Event Dispatch</a>
+    <li><a href="#ref-for-service-worker-global-scope-interface-16">Run Service Worker</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dfn-service-worker-global-scope-service-worker">


### PR DESCRIPTION
In https://github.com/whatwg/html/pull/1487, HTML's script-fetching algorithms were updated and improved. This aligns service worker, which is a heavy consumer of those algorithms, with those changes.

DO NOT MERGE YET. This relies on https://github.com/whatwg/html/pull/1487 first being merged, and then on a day or two for Shepherd to scrape HTML's newly-exported `<dfn>`s, and then I have to rebuild the .html. But feel free to review!!